### PR TITLE
Adding the 吔 character to Jyutping and Jyutping toneless

### DIFF
--- a/DataTables/jyutping-toneless.cin
+++ b/DataTables/jyutping-toneless.cin
@@ -12810,4 +12810,5 @@ laap   𩶘
 laap   鱲
 man    鰵
 bit    𡋾
+jaa    吔
 %chardef end

--- a/DataTables/jyutping.cin
+++ b/DataTables/jyutping.cin
@@ -13365,4 +13365,5 @@ laap6   𩶘
 laap6   鱲
 man5    鰵
 bit6    𡋾
+jaa1    吔
 %chardef end


### PR DESCRIPTION
The character 吔 is not included in the current jyutping.cin. It's not a written character, though. But it's a legit one. http://www.cantonese.sheik.co.uk/dictionary/characters/644/