### PR TITLE
Modifies the behavior of using space as the first candidate key

### DIFF
--- a/Packages/OpenVanilla/Package.swift
+++ b/Packages/OpenVanilla/Package.swift
@@ -32,6 +32,10 @@ let package = Package(
         .target(
             name: "OpenVanillaImpl",
             dependencies: ["OpenVanilla", "CandidateUI"],
+            cSettings: [
+                .unsafeFlags(["-Wno-incomplete-umbrella"], .when(configuration: .release)),
+                .unsafeFlags(["-Wno-incomplete-umbrella"], .when(configuration: .debug))
+            ],
             cxxSettings: [.unsafeFlags(["-fcxx-modules", "-fmodules"])]
         ),
         .target(
@@ -46,6 +50,10 @@ let package = Package(
                            "LoaderService",
                            "CandidateUI", "TooltipUI", "VXHanConvert",
                            "OVIMBig5Code", "OVIMTableBased", "OVIMArray", "OVAFAssociatedPhrases"],
+            cSettings: [
+                .unsafeFlags(["-Wno-incomplete-umbrella"], .when(configuration: .release)),
+                .unsafeFlags(["-Wno-incomplete-umbrella"], .when(configuration: .debug))
+            ],
             cxxSettings: [.unsafeFlags(["-fcxx-modules", "-fmodules"])]
         ),
         .target(

--- a/Packages/OpenVanilla/Sources/LegacyOpenVanilla/include/LegacyOVFrameworkWrapper.h
+++ b/Packages/OpenVanilla/Sources/LegacyOpenVanilla/include/LegacyOVFrameworkWrapper.h
@@ -156,7 +156,7 @@ public:
             m_list->addCandidate(s.substr(2));
         }
 
-        m_panel->setCandidateKeys(candidateKeys, m_service);
+        m_panel->setCandidateKeys(candidateKeys, false, m_service);
         m_panel->updateDisplay();
         return this;
     }

--- a/Packages/OpenVanilla/Sources/OVIMTableBased/OVIMTableBased.cpp
+++ b/Packages/OpenVanilla/Sources/OVIMTableBased/OVIMTableBased.cpp
@@ -38,7 +38,7 @@ OVIMTableBased::OVIMTableBased(const string& tablePath)
     , m_configMaximumRadicalLength(5)
     , m_configSendFirstCandidateWithSpaceWithOnePageList(true)
     , m_configShouldComposeAtMaximumRadicalLength(true)
-    , m_configUseSpaceAsFirstCandidateSelectionKey(false)
+    , m_configUseSpaceAsFirstCandidateSelectionKey(Disabled)
     , m_configMatchOneChar('?')
     , m_configMatchZeroOrMoreChar('*')
     , m_configOnlyUseNumPadNumbersForRadicals(false)
@@ -52,7 +52,7 @@ OVIMTableBased::OVIMTableBased(const string& tablePath)
         m_configMaximumRadicalLength = 2;
     } else if (OVWildcard::Match(filename, "dayi*.cin")) {
         m_configMaximumRadicalLength = 4;
-        m_configUseSpaceAsFirstCandidateSelectionKey = true;
+        m_configUseSpaceAsFirstCandidateSelectionKey = OriginalFirstKeySelectsSecondCandidate;
     } else if (OVWildcard::Match(filename, "ehq*.cin")) {
         m_configMaximumRadicalLength = 10;
         m_configComposeWhileTyping = true;
@@ -194,7 +194,7 @@ void OVIMTableBased::loadConfig(OVKeyValueMap* moduleConfig, OVLoaderService* lo
     }
 
     if (moduleConfig->hasKey("UseSpaceAsFirstCandidateSelectionKey")) {
-        m_configUseSpaceAsFirstCandidateSelectionKey = moduleConfig->isKeyTrue("UseSpaceAsFirstCandidateSelectionKey");
+        m_configUseSpaceAsFirstCandidateSelectionKey = static_cast<UseSpaceAsFirstCandidateSelectionKeyOption>(moduleConfig->intValueForKey("UseSpaceAsFirstCandidateSelectionKey"));
     }
 
     if (moduleConfig->hasKey("OnlyUseNumPadNumbersForRadicals")) {

--- a/Packages/OpenVanilla/Sources/OVIMTableBased/OVIMTableBasedContext.cpp
+++ b/Packages/OpenVanilla/Sources/OVIMTableBased/OVIMTableBasedContext.cpp
@@ -529,9 +529,6 @@ const string OVIMTableBasedContext::createTooltip(const string& sendText)
     }
     
     string queryKey = currentQueryKey();
-    if (stringContainsWildcard(queryKey)) {
-        return "";
-    }
     vector<string> results = m_module->m_table->findKeys(sendText);
     std::sort(results.begin(), results.end(), [](const string& a, const string& b) {
         return a.length() < b.length();
@@ -540,7 +537,7 @@ const string OVIMTableBasedContext::createTooltip(const string& sendText)
         return "";
     }
     string shortQueryKey = results[0];
-    if (queryKey.length() > shortQueryKey.length()) {
+    if (queryKey.length() > shortQueryKey.length() || stringContainsWildcard(queryKey)) {
         std::vector<std::string> shortQueryKeyComponents;
         for (char ch : shortQueryKey) {
             shortQueryKeyComponents.push_back(std::string(1, ch));

--- a/Packages/OpenVanilla/Sources/OVIMTableBased/OVIMTableBasedContext.cpp
+++ b/Packages/OpenVanilla/Sources/OVIMTableBased/OVIMTableBasedContext.cpp
@@ -444,11 +444,15 @@ bool OVIMTableBasedContext::compose(OVTextBuffer* readingText, OVTextBuffer* com
             candidateKeys = "123456789";
         }
 
+        if (m_module->m_configUseSpaceAsFirstCandidateSelectionKey == OriginalFirstKeySelectsSecondCandidate) {
+            candidateKeys = string(" ") + candidateKeys;
+        }
+
         if (results.size() < candidateKeys.length()) {
             candidateKeys = candidateKeys.substr(0, results.size());
         }
 
-        panel->setCandidateKeys(candidateKeys, m_module->m_configUseSpaceAsFirstCandidateSelectionKey, loaderService);
+        panel->setCandidateKeys(candidateKeys, m_module->m_configUseSpaceAsFirstCandidateSelectionKey == SpaceAndOriginalFirstKeySelectsFirstCandidate, loaderService);
 
         OVKeyVector nextPageKeys;
         if (results.size() <= candidateKeys.length() && (m_module->m_configUseSpaceAsFirstCandidateSelectionKey || m_module->m_configSendFirstCandidateWithSpaceWithOnePageList)) {

--- a/Packages/OpenVanilla/Sources/OVIMTableBased/OVIMTableBasedContext.cpp
+++ b/Packages/OpenVanilla/Sources/OVIMTableBased/OVIMTableBasedContext.cpp
@@ -439,19 +439,16 @@ bool OVIMTableBasedContext::compose(OVTextBuffer* readingText, OVTextBuffer* com
         candidates->setCandidates(results);
 
         string candidateKeys = m_module->m_table->findProperty("selkey");
+
         if (!candidateKeys.length()) {
             candidateKeys = "123456789";
-        }
-
-        if (m_module->m_configUseSpaceAsFirstCandidateSelectionKey) {
-            candidateKeys = string(" ") + candidateKeys;
         }
 
         if (results.size() < candidateKeys.length()) {
             candidateKeys = candidateKeys.substr(0, results.size());
         }
 
-        panel->setCandidateKeys(candidateKeys, loaderService);
+        panel->setCandidateKeys(candidateKeys, m_module->m_configUseSpaceAsFirstCandidateSelectionKey, loaderService);
 
         OVKeyVector nextPageKeys;
         if (results.size() <= candidateKeys.length() && (m_module->m_configUseSpaceAsFirstCandidateSelectionKey || m_module->m_configSendFirstCandidateWithSpaceWithOnePageList)) {

--- a/Packages/OpenVanilla/Sources/OVIMTableBased/include/OVIMTableBased.h
+++ b/Packages/OpenVanilla/Sources/OVIMTableBased/include/OVIMTableBased.h
@@ -36,6 +36,12 @@ namespace OpenVanilla {
 
     class OVIMTableBasedContext;
 
+    enum UseSpaceAsFirstCandidateSelectionKeyOption {
+        Disabled,
+        OriginalFirstKeySelectsSecondCandidate,
+        SpaceAndOriginalFirstKeySelectsFirstCandidate,
+    };
+
     class OVIMTableBased : public OVInputMethod {
     public:
         OVIMTableBased(const string& tablePath);
@@ -68,7 +74,7 @@ namespace OpenVanilla {
         size_t m_configMaximumRadicalLength;
         bool m_configSendFirstCandidateWithSpaceWithOnePageList;
         bool m_configShouldComposeAtMaximumRadicalLength;
-        bool m_configUseSpaceAsFirstCandidateSelectionKey;
+        UseSpaceAsFirstCandidateSelectionKeyOption m_configUseSpaceAsFirstCandidateSelectionKey;
         bool m_configOnlyUseNumPadNumbersForRadicals;
         bool m_specialCodePrompt;
     };

--- a/Packages/OpenVanilla/Sources/OpenVanilla/include/OVCandidateService.h
+++ b/Packages/OpenVanilla/Sources/OpenVanilla/include/OVCandidateService.h
@@ -118,13 +118,14 @@ namespace OpenVanilla {
         virtual size_t goToPage(size_t page) = 0;
 
         virtual const OVKey candidateKeyAtIndex(size_t index) = 0;
-        virtual void setCandidateKeys(const string& asciiKeys, OVLoaderService* loaderService)
+        virtual void setCandidateKeys(const string& asciiKeys, bool useSpaceAsFirstCandidateSelectionKey, OVLoaderService* loaderService)
         {
             OVKeyVector keys;
             for (size_t index = 0; index < asciiKeys.length(); index++) {
                 keys.push_back(loaderService->makeOVKey(asciiKeys[index]));
             }
-            
+
+            m_useSpaceAsFirstCandidateSelectionKey = useSpaceAsFirstCandidateSelectionKey;
             setCandidateKeys(keys);
             setCandidatesPerPage(asciiKeys.length());
         }
@@ -146,6 +147,12 @@ namespace OpenVanilla {
         virtual const OVKeyVector defaultChooseHighlightedCandidateKeys() const = 0;
 
         virtual void setCandidateKeysAndLabels(const vector<pair<OVKey, string> >& keyLabelPairs) = 0;
+        virtual const bool useSpaceAsFirstCandidateSelectionKey() {
+            return m_useSpaceAsFirstCandidateSelectionKey;
+        }
+
+    private:
+        bool m_useSpaceAsFirstCandidateSelectionKey = false;
     };
 
     class OVFreeContentStorage : public OVBase {

--- a/Packages/OpenVanilla/Sources/OpenVanillaImpl/OVOneDimensionalCandidatePanelImpl.mm
+++ b/Packages/OpenVanilla/Sources/OpenVanillaImpl/OVOneDimensionalCandidatePanelImpl.mm
@@ -361,12 +361,19 @@ void OVOneDimensionalCandidatePanelImpl::setCandidateKeys(const OVKeyVector& key
     NSMutableArray *labels = [NSMutableArray array];
     for (OVKeyVector::const_iterator i = keys.begin(), e = keys.end(); i != e; ++i) {
         NSString *key = nil;
+        NSString *diaplayedText = nil;
         if (i == keys.begin() && useSpaceAsFirstCandidateSelectionKey()) {
-            key = @"␣";
+            key = @" ";
+            diaplayedText = @"␣";
         } else {
             key = @((*i).receivedString().c_str());
+            if ([key isEqualToString:@" "]) {
+                diaplayedText = @"␣";
+            } else {
+                diaplayedText = key;
+            }
         }
-        VTCandidateKeyLabel *label = [[VTCandidateKeyLabel alloc] initWithKey:key displayedText:key];
+        VTCandidateKeyLabel *label = [[VTCandidateKeyLabel alloc] initWithKey:key displayedText:diaplayedText];
         [labels addObject:label];
     }
 

--- a/Packages/OpenVanilla/Sources/OpenVanillaImpl/OVOneDimensionalCandidatePanelImpl.mm
+++ b/Packages/OpenVanilla/Sources/OpenVanillaImpl/OVOneDimensionalCandidatePanelImpl.mm
@@ -140,6 +140,7 @@ OVOneDimensionalCandidatePanelImpl::OVOneDimensionalCandidatePanelImpl(Class pan
     m_nextPageKeys = m_defaultNextPageKeys;
     m_previousCandidateKeys = m_defaultPreviousCandidateKeys;
     m_previousPageKeys = m_defaultPreviousPageKeys;
+    m_spaceKeys.push_back(loaderService->makeOVKey(OVKeyCode::Space));
 
     applyFontSettings();
 }
@@ -359,7 +360,12 @@ void OVOneDimensionalCandidatePanelImpl::setCandidateKeys(const OVKeyVector& key
     m_candidateKeys = keys;
     NSMutableArray *labels = [NSMutableArray array];
     for (OVKeyVector::const_iterator i = keys.begin(), e = keys.end(); i != e; ++i) {
-        NSString *key = @((*i).receivedString().c_str());
+        NSString *key = nil;
+        if (i == keys.begin() && useSpaceAsFirstCandidateSelectionKey()) {
+            key = @"␣";
+        } else {
+            key = @((*i).receivedString().c_str());
+        }
         VTCandidateKeyLabel *label = [[VTCandidateKeyLabel alloc] initWithKey:key displayedText:key];
         [labels addObject:label];
     }
@@ -441,7 +447,12 @@ OVOneDimensionalCandidatePanelImpl::KeyHandlerResult OVOneDimensionalCandidatePa
 {
     size_t selectedCandidateKeyIndex;
 
-    if (IsKeyInList(key, m_candidateKeys, &selectedCandidateKeyIndex)) {
+    if (useSpaceAsFirstCandidateSelectionKey() && IsKeyInList(key, m_spaceKeys)) {
+        hide();
+        m_inControl = false;
+        setHighlightIndex(0);
+        return CandidateSelected;
+    } else if (IsKeyInList(key, m_candidateKeys, &selectedCandidateKeyIndex)) {
         if (selectedCandidateKeyIndex >= currentPageCandidateCount()) {
             return Invalid;
         }

--- a/Packages/OpenVanilla/Sources/OpenVanillaImpl/include/OVOneDimensionalCandidatePanelImpl.h
+++ b/Packages/OpenVanilla/Sources/OpenVanillaImpl/include/OVOneDimensionalCandidatePanelImpl.h
@@ -130,5 +130,6 @@ namespace OpenVanilla {
         OVKeyVector m_defaultPreviousPageKeys;
         OVKeyVector m_defaultNextCandidateKeys;
         OVKeyVector m_defaultPreviousCandidateKeys;
+        OVKeyVector m_spaceKeys;
     };
 };

--- a/Source/Mac/OVInputMethodController.mm
+++ b/Source/Mac/OVInputMethodController.mm
@@ -108,7 +108,8 @@ using namespace OpenVanilla;
     [menu addItem:[NSMenuItem separatorItem]];
 
     NSMenuItem *filterItem;
-    filterItem = [[NSMenuItem alloc] initWithTitle:NSLocalizedString(@"Convert Traditional Chinese to Simplified", @"") action:@selector(toggleTraditionalToSimplifiedChineseFilterAction:) keyEquivalent:@""];
+    filterItem = [[NSMenuItem alloc] initWithTitle:NSLocalizedString(@"Convert Traditional Chinese to Simplified", @"") action:@selector(toggleTraditionalToSimplifiedChineseFilterAction:) keyEquivalent:@"g"];
+    [filterItem setKeyEquivalentModifierMask:NSEventModifierFlagCommand | NSEventModifierFlagControl];
     filterItem.state = [OVModuleManager defaultManager].traditionalToSimplifiedChineseFilterEnabled ? NSControlStateValueOn : NSControlStateValueOff;
     [menu addItem:filterItem];
 

--- a/Source/Mac/Preferences/TableBasedModulePreferencesViewController.swift
+++ b/Source/Mac/Preferences/TableBasedModulePreferencesViewController.swift
@@ -38,7 +38,7 @@ class TableBasedModulePreferencesViewController: BaseModulePreferencesViewContro
     @IBOutlet var fieldShouldComposeAtMaximumRadicalLength: NSButton!
     @IBOutlet var fieldUseSpaceAsFirstCandidateSelectionKey: NSMatrix!
     @IBOutlet var fieldSpecialCodePrompt: NSButton!
-    @IBOutlet var cusmtomTableBasedInputMethodInfo: NSTextField!
+    @IBOutlet var customTableBasedInputMethodInfo: NSTextField!
     @IBOutlet var removeInputMethodButton: NSButton!
 
     override var moduleIdentifier: String! {
@@ -59,11 +59,11 @@ class TableBasedModulePreferencesViewController: BaseModulePreferencesViewContro
 
         let manager = OVModuleManager.default
         if manager.isCustomTableBasedInputMethod(moduleIdentifier) {
-            cusmtomTableBasedInputMethodInfo.stringValue = NSLocalizedString(
+            customTableBasedInputMethodInfo.stringValue = NSLocalizedString(
                 "This is a customized input method.", comment: "")
             removeInputMethodButton.isHidden = false
         } else {
-            cusmtomTableBasedInputMethodInfo.stringValue = NSLocalizedString(
+            customTableBasedInputMethodInfo.stringValue = NSLocalizedString(
                 "This is a built-in input method.", comment: "")
             removeInputMethodButton.isHidden = true
         }

--- a/Source/Mac/Preferences/TableBasedModulePreferencesViewController.swift
+++ b/Source/Mac/Preferences/TableBasedModulePreferencesViewController.swift
@@ -36,7 +36,7 @@ class TableBasedModulePreferencesViewController: BaseModulePreferencesViewContro
     @IBOutlet var fieldComposeWhileTyping: NSButton!
     @IBOutlet var fieldSendFirstCandidateWithSpaceWithOnePageList: NSButton!
     @IBOutlet var fieldShouldComposeAtMaximumRadicalLength: NSButton!
-    @IBOutlet var fieldUseSpaceAsFirstCandidateSelectionKey: NSButton!
+    @IBOutlet var fieldUseSpaceAsFirstCandidateSelectionKey: NSMatrix!
     @IBOutlet var fieldSpecialCodePrompt: NSButton!
     @IBOutlet var cusmtomTableBasedInputMethodInfo: NSTextField!
     @IBOutlet var removeInputMethodButton: NSButton!
@@ -79,14 +79,24 @@ class TableBasedModulePreferencesViewController: BaseModulePreferencesViewContro
             for: fieldSpecialCodePrompt,
             key: "SpecialCodePrompt")
 
-        if boolValue(forKey: "UseSpaceAsFirstCandidateSelectionKey") {
-            fieldUseSpaceAsFirstCandidateSelectionKey.state = .on
+        var useSpaceAsFirstCandidateSelectionKey =
+            unsignedIntegerValue(forKey: "UseSpaceAsFirstCandidateSelectionKey") ?? 0
+
+        let legacyUseSpaceAsFirstCandidateSelectionKey = boolValue(
+            forKey: "UseSpaceAsFirstCandidateSelectionKey")
+        if legacyUseSpaceAsFirstCandidateSelectionKey {
+            useSpaceAsFirstCandidateSelectionKey = 1
+        }
+
+        if useSpaceAsFirstCandidateSelectionKey != 0 {
+            fieldUseSpaceAsFirstCandidateSelectionKey.selectCell(withTag: Int(
+                useSpaceAsFirstCandidateSelectionKey))
             fieldSendFirstCandidateWithSpaceWithOnePageList.state = .off
         } else if boolValue(forKey: "SendFirstCandidateWithSpaceWithOnePageList") {
-            fieldUseSpaceAsFirstCandidateSelectionKey.state = .on
+            fieldUseSpaceAsFirstCandidateSelectionKey.selectCell(withTag: 1)
             fieldSendFirstCandidateWithSpaceWithOnePageList.state = .on
         } else {
-            fieldUseSpaceAsFirstCandidateSelectionKey.state = .off
+            fieldUseSpaceAsFirstCandidateSelectionKey.selectCell(withTag: 0)
             fieldSendFirstCandidateWithSpaceWithOnePageList.state = .off
         }
 
@@ -109,12 +119,12 @@ class TableBasedModulePreferencesViewController: BaseModulePreferencesViewContro
 
     @IBAction func updateField(_ sender: NSObject) {
         if sender == fieldUseSpaceAsFirstCandidateSelectionKey {
-            if fieldUseSpaceAsFirstCandidateSelectionKey.state == .on {
+            if fieldUseSpaceAsFirstCandidateSelectionKey.selectedTag() != 0 {
                 fieldSendFirstCandidateWithSpaceWithOnePageList.state = .off
             }
         } else if sender == fieldSendFirstCandidateWithSpaceWithOnePageList {
             if fieldSendFirstCandidateWithSpaceWithOnePageList.state == .on {
-                fieldUseSpaceAsFirstCandidateSelectionKey.state = .off
+                fieldUseSpaceAsFirstCandidateSelectionKey.selectCell(withTag: 0)
             }
         } else if sender == fieldAlphaNumericKeyboardLayout {
             if let layout = fieldAlphaNumericKeyboardLayout.selectedItem?.representedObject
@@ -131,8 +141,8 @@ class TableBasedModulePreferencesViewController: BaseModulePreferencesViewContro
         setBoolValue(
             fieldShouldComposeAtMaximumRadicalLength.state == .on,
             forKey: "ShouldComposeAtMaximumRadicalLength")
-        setBoolValue(
-            fieldUseSpaceAsFirstCandidateSelectionKey.state == .on,
+        setUnsignedIntegerValue(
+            UInt(fieldUseSpaceAsFirstCandidateSelectionKey.selectedTag()),
             forKey: "UseSpaceAsFirstCandidateSelectionKey")
         setBoolValue(
             fieldSendFirstCandidateWithSpaceWithOnePageList.state == .on,
@@ -140,7 +150,6 @@ class TableBasedModulePreferencesViewController: BaseModulePreferencesViewContro
         setBoolValue(
             fieldSpecialCodePrompt.state == .on,
             forKey: "SpecialCodePrompt")
-
 
         let selectedItem = fieldMaximumRadicalLength.selectedItem
         if let selectedItem {

--- a/Source/Mac/UpdateChecker.swift
+++ b/Source/Mac/UpdateChecker.swift
@@ -17,11 +17,11 @@ class UpdateChecker: NSObject {
     private(set) var busy = false
 
     @objc
-    @UserDefault (key: OVLastUpdateCheckTimeKey, defaultValue: nil)
+    @UserDefault(key: OVLastUpdateCheckTimeKey, defaultValue: nil)
     private(set) var lastUpdateCheckDate: Date?
 
     @objc
-    @UserDefault (key: OVNextUpdateCheckTimeKey, defaultValue: nil)
+    @UserDefault(key: OVNextUpdateCheckTimeKey, defaultValue: nil)
     private(set) var nextUpdateCheckDate: Date?
 
     private var connection: URLSessionDataTask?

--- a/Source/Mac/UserDefaultsPropertyWrapper.swift
+++ b/Source/Mac/UserDefaultsPropertyWrapper.swift
@@ -8,7 +8,7 @@ struct UserDefault<T> {
 
     var wrappedValue: T {
         get {
-            return UserDefaults.standard.object(forKey: key) as? T ?? defaultValue
+            UserDefaults.standard.object(forKey: key) as? T ?? defaultValue
         }
         set {
             UserDefaults.standard.set(newValue, forKey: key)

--- a/Source/Mac/en.lproj/Localizable.strings
+++ b/Source/Mac/en.lproj/Localizable.strings
@@ -174,3 +174,7 @@
 "After a candidate is chosen:" = "After a candidate is chosen:";
 "Keep showing new candidates" = "Keep showing new candidates";
 "Always use the keyboard layout when Shift key is pressed" = "Always use it with Shift";
+"Use space as the first candidate key:" = "Use Space as the first candidate key:";
+"Disabled" = "Disabled";
+"Original first key selects the second candidate" = "Original first key selects the second candidate";
+"Both space and the first key selects the first candidate" = "Both Space and the first key selects the first candidate";

--- a/Source/Mac/preferences.xib
+++ b/Source/Mac/preferences.xib
@@ -24,21 +24,21 @@
         <window title="OpenVanilla Preference - General" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" visibleAtLaunch="NO" animationBehavior="default" id="1">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="121" y="123" width="640" height="260"/>
+            <rect key="contentRect" x="121" y="123" width="640" height="364"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1055"/>
             <view key="contentView" id="2">
-                <rect key="frame" x="0.0" y="0.0" width="640" height="260"/>
+                <rect key="frame" x="0.0" y="0.0" width="640" height="364"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <scrollView fixedFrame="YES" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3">
-                        <rect key="frame" x="0.0" y="0.0" width="200" height="260"/>
+                        <rect key="frame" x="0.0" y="1" width="200" height="363"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <clipView key="contentView" id="APL-TT-LOB">
-                            <rect key="frame" x="1" y="1" width="198" height="258"/>
+                            <rect key="frame" x="1" y="1" width="198" height="361"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" id="4">
-                                    <rect key="frame" x="0.0" y="0.0" width="198" height="258"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="198" height="361"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <size key="intercellSpacing" width="3" height="2"/>
                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -74,7 +74,7 @@
                         </scroller>
                     </scrollView>
                     <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="59">
-                        <rect key="frame" x="200" y="0.0" width="440" height="260"/>
+                        <rect key="frame" x="200" y="0.0" width="440" height="364"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     </customView>
                 </subviews>
@@ -82,14 +82,14 @@
             <connections>
                 <outlet property="delegate" destination="-2" id="183"/>
             </connections>
-            <point key="canvasLocation" x="-193" y="109"/>
+            <point key="canvasLocation" x="210" y="-109"/>
         </window>
         <customView id="12">
-            <rect key="frame" x="0.0" y="0.0" width="440" height="260"/>
+            <rect key="frame" x="0.0" y="0.0" width="440" height="364"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="83">
-                    <rect key="frame" x="18" y="157" width="389" height="18"/>
+                    <rect key="frame" x="18" y="261" width="389" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Compose when reaching the maximum component length" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="84">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -100,7 +100,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="13">
-                    <rect key="frame" x="18" y="137" width="261" height="18"/>
+                    <rect key="frame" x="18" y="241" width="261" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Clear the composing buffer on error" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="14">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -111,7 +111,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="15">
-                    <rect key="frame" x="18" y="117" width="375" height="18"/>
+                    <rect key="frame" x="18" y="221" width="375" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="While typing, show candidate list if there are candidates" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="16">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -121,30 +121,8 @@
                         <action selector="updateField:" target="69" id="95"/>
                     </connections>
                 </button>
-                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="17">
-                    <rect key="frame" x="18" y="77" width="402" height="18"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <buttonCell key="cell" type="check" title="Space selects the first candidate when there's only one page" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="18">
-                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                        <font key="font" metaFont="system"/>
-                    </buttonCell>
-                    <connections>
-                        <action selector="updateField:" target="69" id="97"/>
-                    </connections>
-                </button>
-                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="19">
-                    <rect key="frame" x="18" y="97" width="248" height="18"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <buttonCell key="cell" type="check" title="Use Space as the first candidate key" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="20">
-                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                        <font key="font" metaFont="system"/>
-                    </buttonCell>
-                    <connections>
-                        <action selector="updateField:" target="69" id="96"/>
-                    </connections>
-                </button>
                 <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="75">
-                    <rect key="frame" x="17" y="223" width="233" height="17"/>
+                    <rect key="frame" x="17" y="327" width="233" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Maximum component buffer length:" id="76">
                         <font key="font" metaFont="system"/>
@@ -153,7 +131,7 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="77">
-                    <rect key="frame" x="252" y="217" width="77" height="26"/>
+                    <rect key="frame" x="252" y="321" width="77" height="26"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <popUpButtonCell key="cell" type="push" title="100" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="112" id="78">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -186,7 +164,7 @@
                     </connections>
                 </popUpButton>
                 <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="124">
-                    <rect key="frame" x="17" y="189" width="233" height="17"/>
+                    <rect key="frame" x="17" y="293" width="233" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Alphanumeric keyboard layout:" id="131">
                         <font key="font" metaFont="system"/>
@@ -195,7 +173,7 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="125">
-                    <rect key="frame" x="252" y="183" width="164" height="26"/>
+                    <rect key="frame" x="252" y="287" width="164" height="26"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <popUpButtonCell key="cell" type="push" title="Item 1" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="130" id="126">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -213,7 +191,7 @@
                     </connections>
                 </popUpButton>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="132">
-                    <rect key="frame" x="249" y="13" width="176" height="32"/>
+                    <rect key="frame" x="248" y="13" width="176" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="push" title="Remove Input Method" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="133">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -224,7 +202,7 @@
                     </connections>
                 </button>
                 <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="134">
-                    <rect key="frame" x="18" y="22" width="232" height="17"/>
+                    <rect key="frame" x="17" y="22" width="232" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="This is a customized input method." id="135">
                         <font key="font" metaFont="smallSystem"/>
@@ -233,7 +211,7 @@
                     </textFieldCell>
                 </textField>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cm9-2B-Eff">
-                    <rect key="frame" x="18" y="55" width="404" height="18"/>
+                    <rect key="frame" x="18" y="199" width="404" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Prompt for a shorter combination if available" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="DyU-rh-Fp1">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -243,15 +221,69 @@
                         <action selector="updateField:" target="69" id="dvI-g8-TPo"/>
                     </connections>
                 </button>
+                <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="maI-Yg-HFe">
+                    <rect key="frame" x="19" y="186" width="401" height="5"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                </box>
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="d1h-Gp-njO">
+                    <rect key="frame" x="18" y="164" width="227" height="16"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" lineBreakMode="clipping" title="Use space as the first candidate key:" id="VMK-sQ-0rx">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <matrix verticalHuggingPriority="750" verticalCompressionResistancePriority="741" fixedFrame="YES" allowsEmptySelection="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6y2-gG-MYD">
+                    <rect key="frame" x="20" y="91" width="387" height="64"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    <size key="cellSize" width="387" height="20"/>
+                    <size key="intercellSpacing" width="4" height="2"/>
+                    <buttonCell key="prototype" type="radio" title="Radio" imagePosition="left" alignment="left" inset="2" id="pPM-Cb-F7v">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <cells>
+                        <column>
+                            <buttonCell type="radio" title="Disabled" imagePosition="left" alignment="left" state="on" inset="2" id="IX2-I5-CCl">
+                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                <font key="font" metaFont="system"/>
+                            </buttonCell>
+                            <buttonCell type="radio" title="Original first key selects the second candidate" imagePosition="left" alignment="left" tag="1" inset="2" id="H8G-2y-7NT">
+                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                <font key="font" metaFont="system"/>
+                            </buttonCell>
+                            <buttonCell type="radio" title="Both space and the first key selects the first candidate" imagePosition="left" alignment="left" tag="2" inset="2" id="yUy-0m-M50">
+                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                <font key="font" metaFont="system"/>
+                            </buttonCell>
+                        </column>
+                    </cells>
+                    <connections>
+                        <action selector="updateField:" target="69" id="3jA-7h-Jbd"/>
+                    </connections>
+                </matrix>
+                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="17">
+                    <rect key="frame" x="19" y="66" width="402" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="check" title="Space selects the first candidate when there's only one page" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="18">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="updateField:" target="69" id="97"/>
+                    </connections>
+                </button>
             </subviews>
-            <point key="canvasLocation" x="-180" y="-205"/>
+            <point key="canvasLocation" x="-373" y="-122"/>
         </customView>
         <customView id="21">
-            <rect key="frame" x="0.0" y="0.0" width="440" height="264"/>
+            <rect key="frame" x="0.0" y="0.0" width="440" height="364"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="22">
-                    <rect key="frame" x="220" y="220" width="67" height="26"/>
+                    <rect key="frame" x="220" y="320" width="67" height="26"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <popUpButtonCell key="cell" type="push" title="16" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="27" id="23">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -289,7 +321,7 @@
                     </connections>
                 </popUpButton>
                 <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="28">
-                    <rect key="frame" x="36" y="226" width="182" height="17"/>
+                    <rect key="frame" x="36" y="326" width="182" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Candidate list font size:" id="29">
                         <font key="font" metaFont="system"/>
@@ -298,7 +330,7 @@
                     </textFieldCell>
                 </textField>
                 <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="52">
-                    <rect key="frame" x="36" y="201" width="182" height="17"/>
+                    <rect key="frame" x="36" y="301" width="182" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Candidate list style:" id="53">
                         <font key="font" metaFont="system"/>
@@ -307,7 +339,7 @@
                     </textFieldCell>
                 </textField>
                 <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="114">
-                    <rect key="frame" x="36" y="98" width="182" height="17"/>
+                    <rect key="frame" x="36" y="198" width="182" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Feedback:" id="115">
                         <font key="font" metaFont="system"/>
@@ -325,7 +357,7 @@
                     </textFieldCell>
                 </textField>
                 <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="44">
-                    <rect key="frame" x="17" y="154" width="201" height="17"/>
+                    <rect key="frame" x="17" y="254" width="201" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Alphanumeric keyboard layout:" id="45">
                         <font key="font" metaFont="system"/>
@@ -334,7 +366,7 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="38">
-                    <rect key="frame" x="220" y="148" width="165" height="26"/>
+                    <rect key="frame" x="220" y="248" width="165" height="26"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <popUpButtonCell key="cell" type="push" title="Item 1" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="41" id="39">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -352,7 +384,7 @@
                     </connections>
                 </popUpButton>
                 <matrix verticalHuggingPriority="750" fixedFrame="YES" allowsEmptySelection="NO" autosizesCells="NO" translatesAutoresizingMaskIntoConstraints="NO" id="48">
-                    <rect key="frame" x="223" y="180" width="124" height="38"/>
+                    <rect key="frame" x="223" y="280" width="124" height="38"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     <size key="cellSize" width="124" height="18"/>
@@ -378,7 +410,7 @@
                     </connections>
                 </matrix>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="54">
-                    <rect key="frame" x="221" y="97" width="201" height="18"/>
+                    <rect key="frame" x="221" y="197" width="201" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Play sound on input error" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="55">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -420,7 +452,7 @@
                     </textFieldCell>
                 </textField>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="R6g-Wq-3w5">
-                    <rect key="frame" x="220" y="127" width="200" height="18"/>
+                    <rect key="frame" x="220" y="227" width="200" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Always use the keyboard layout when Shift key is pressed" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="LyX-as-mRk">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -443,7 +475,7 @@
                 <outlet property="fieldSendFirstCandidateWithSpaceWithOnePageList" destination="17" id="91"/>
                 <outlet property="fieldShouldComposeAtMaximumRadicalLength" destination="83" id="87"/>
                 <outlet property="fieldSpecialCodePrompt" destination="cm9-2B-Eff" id="eSU-p8-0K4"/>
-                <outlet property="fieldUseSpaceAsFirstCandidateSelectionKey" destination="19" id="90"/>
+                <outlet property="fieldUseSpaceAsFirstCandidateSelectionKey" destination="6y2-gG-MYD" id="p8f-L8-wb4"/>
                 <outlet property="removeInputMethodButton" destination="132" id="178"/>
                 <outlet property="view" destination="12" id="71"/>
             </connections>
@@ -476,11 +508,11 @@
             </connections>
         </viewController>
         <customView id="136">
-            <rect key="frame" x="0.0" y="0.0" width="440" height="260"/>
+            <rect key="frame" x="0.0" y="0.0" width="440" height="364"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="137">
-                    <rect key="frame" x="133" y="128" width="174" height="32"/>
+                    <rect key="frame" x="133" y="232" width="174" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="push" title="Import…" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="138">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -491,7 +523,7 @@
                     </connections>
                 </button>
                 <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="141">
-                    <rect key="frame" x="71" y="182" width="289" height="34"/>
+                    <rect key="frame" x="71" y="286" width="289" height="34"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="Create a customized input method by importing a .cin file" id="142">
                         <font key="font" metaFont="system"/>
@@ -500,7 +532,7 @@
                     </textFieldCell>
                 </textField>
                 <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="143">
-                    <rect key="frame" x="114" y="75" width="212" height="34"/>
+                    <rect key="frame" x="114" y="179" width="212" height="34"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="For more information, visit http://openvanilla.org" id="144">
                         <font key="font" metaFont="system"/>
@@ -512,11 +544,11 @@
             <point key="canvasLocation" x="110" y="-530"/>
         </customView>
         <customView id="145">
-            <rect key="frame" x="0.0" y="0.0" width="440" height="260"/>
+            <rect key="frame" x="0.0" y="0.0" width="440" height="364"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="U7e-Qz-w2m">
-                    <rect key="frame" x="-2" y="221" width="233" height="17"/>
+                    <rect key="frame" x="-2" y="325" width="233" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Alphanumeric keyboard layout:" id="g9u-AH-pAp">
                         <font key="font" metaFont="system"/>
@@ -525,7 +557,7 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="v1r-B2-JDD">
-                    <rect key="frame" x="233" y="215" width="164" height="26"/>
+                    <rect key="frame" x="233" y="319" width="164" height="26"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <popUpButtonCell key="cell" type="push" title="Item 1" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="kTI-Rt-Msi" id="z6H-EZ-057">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -543,7 +575,7 @@
                     </connections>
                 </popUpButton>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="146">
-                    <rect key="frame" x="18" y="184" width="404" height="18"/>
+                    <rect key="frame" x="18" y="288" width="404" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Prompt for a shorter combination if available" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="147">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -554,7 +586,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="148">
-                    <rect key="frame" x="18" y="164" width="404" height="18"/>
+                    <rect key="frame" x="18" y="268" width="404" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Only allow the shortest combination" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="149">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -568,11 +600,11 @@
             <point key="canvasLocation" x="-200" y="449"/>
         </customView>
         <customView id="Sdw-aj-CtP">
-            <rect key="frame" x="0.0" y="0.0" width="440" height="260"/>
+            <rect key="frame" x="0.0" y="0.0" width="440" height="364"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="WVL-Wd-oMk">
-                    <rect key="frame" x="204" y="216" width="201" height="26"/>
+                    <rect key="frame" x="204" y="320" width="201" height="26"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <popUpButtonCell key="cell" type="push" title="Item 1" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="bon-Uo-fae" id="1jX-fC-EDI">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -590,7 +622,7 @@
                     </connections>
                 </popUpButton>
                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Bls-0d-kSy">
-                    <rect key="frame" x="18" y="221" width="182" height="17"/>
+                    <rect key="frame" x="18" y="325" width="182" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Selection keys:" id="zVd-rT-Z8z">
                         <font key="font" metaFont="system"/>
@@ -599,7 +631,7 @@
                     </textFieldCell>
                 </textField>
                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uqx-6g-kZ1">
-                    <rect key="frame" x="18" y="197" width="182" height="17"/>
+                    <rect key="frame" x="18" y="301" width="182" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="After a candidate is chosen:" id="gXZ-4Y-ES9">
                         <font key="font" metaFont="system"/>
@@ -608,7 +640,7 @@
                     </textFieldCell>
                 </textField>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="awe-EY-NXM">
-                    <rect key="frame" x="204" y="195" width="218" height="18"/>
+                    <rect key="frame" x="204" y="299" width="218" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Keep showing new candidates" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="B8m-Cr-x4L">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -619,7 +651,7 @@
                     </connections>
                 </button>
             </subviews>
-            <point key="canvasLocation" x="-373" y="774"/>
+            <point key="canvasLocation" x="-683" y="449"/>
         </customView>
         <viewController id="OTa-5M-Vdi" customClass="OVAFAssociatedPhrasesPreferencesViewController">
             <connections>

--- a/Source/Mac/preferences.xib
+++ b/Source/Mac/preferences.xib
@@ -35,7 +35,7 @@
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <clipView key="contentView" id="APL-TT-LOB">
                             <rect key="frame" x="1" y="1" width="198" height="361"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <autoresizingMask key="autoresizingMask"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" id="4">
                                     <rect key="frame" x="0.0" y="0.0" width="198" height="361"/>
@@ -121,7 +121,7 @@
                         <action selector="updateField:" target="69" id="95"/>
                     </connections>
                 </button>
-                <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="75">
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="75">
                     <rect key="frame" x="17" y="327" width="233" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Maximum component buffer length:" id="76">
@@ -163,7 +163,7 @@
                         <action selector="updateField:" target="69" id="92"/>
                     </connections>
                 </popUpButton>
-                <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="124">
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="124">
                     <rect key="frame" x="17" y="293" width="233" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Alphanumeric keyboard layout:" id="131">
@@ -201,7 +201,7 @@
                         <action selector="removeInputMethodAction:" target="69" id="176"/>
                     </connections>
                 </button>
-                <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="134">
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="134">
                     <rect key="frame" x="17" y="22" width="232" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="This is a customized input method." id="135">
@@ -225,7 +225,7 @@
                     <rect key="frame" x="19" y="186" width="401" height="5"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                 </box>
-                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="d1h-Gp-njO">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="d1h-Gp-njO">
                     <rect key="frame" x="18" y="164" width="227" height="16"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="Use space as the first candidate key:" id="VMK-sQ-0rx">
@@ -320,7 +320,7 @@
                         <action selector="updateField:" target="70" id="161"/>
                     </connections>
                 </popUpButton>
-                <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="28">
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="28">
                     <rect key="frame" x="36" y="326" width="182" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Candidate list font size:" id="29">
@@ -329,7 +329,7 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="52">
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="52">
                     <rect key="frame" x="36" y="301" width="182" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Candidate list style:" id="53">
@@ -338,7 +338,7 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="114">
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="114">
                     <rect key="frame" x="36" y="198" width="182" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Feedback:" id="115">
@@ -347,7 +347,7 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="116">
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="116">
                     <rect key="frame" x="36" y="73" width="182" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Update Check:" id="117">
@@ -356,7 +356,7 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="44">
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="44">
                     <rect key="frame" x="17" y="254" width="201" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Alphanumeric keyboard layout:" id="45">
@@ -442,7 +442,7 @@
                         <action selector="checkForUpdateAction:" target="70" id="160"/>
                     </connections>
                 </button>
-                <textField hidden="YES" focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="122">
+                <textField hidden="YES" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="122">
                     <rect key="frame" x="220" y="20" width="203" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Last checked: December 31, 2011" id="123">
@@ -467,7 +467,7 @@
         </customView>
         <viewController id="69" customClass="OVTableBasedModulePreferencesViewController">
             <connections>
-                <outlet property="cusmtomTableBasedInputMethodInfo" destination="134" id="177"/>
+                <outlet property="customTableBasedInputMethodInfo" destination="134" id="EKX-Oh-XYv"/>
                 <outlet property="fieldAlphaNumericKeyboardLayout" destination="125" id="153"/>
                 <outlet property="fieldClearReadingBufferAtCompositionError" destination="13" id="88"/>
                 <outlet property="fieldComposeWhileTyping" destination="15" id="89"/>
@@ -522,7 +522,7 @@
                         <action selector="importNewTableAction:" target="168" id="173"/>
                     </connections>
                 </button>
-                <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="141">
+                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="141">
                     <rect key="frame" x="71" y="286" width="289" height="34"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="Create a customized input method by importing a .cin file" id="142">
@@ -531,7 +531,7 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="143">
+                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="143">
                     <rect key="frame" x="114" y="179" width="212" height="34"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="For more information, visit http://openvanilla.org" id="144">
@@ -547,7 +547,7 @@
             <rect key="frame" x="0.0" y="0.0" width="440" height="364"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="U7e-Qz-w2m">
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="U7e-Qz-w2m">
                     <rect key="frame" x="-2" y="325" width="233" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Alphanumeric keyboard layout:" id="g9u-AH-pAp">
@@ -621,7 +621,7 @@
                         <action selector="updateField:" target="OTa-5M-Vdi" id="fhY-JS-3Uk"/>
                     </connections>
                 </popUpButton>
-                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Bls-0d-kSy">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Bls-0d-kSy">
                     <rect key="frame" x="18" y="325" width="182" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Selection keys:" id="zVd-rT-Z8z">
@@ -630,7 +630,7 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uqx-6g-kZ1">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uqx-6g-kZ1">
                     <rect key="frame" x="18" y="301" width="182" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="After a candidate is chosen:" id="gXZ-4Y-ES9">

--- a/Source/Mac/zh-Hans.lproj/Localizable.strings
+++ b/Source/Mac/zh-Hans.lproj/Localizable.strings
@@ -143,3 +143,7 @@
 "After a candidate is chosen:" = "选完联想字词后：";
 "Keep showing new candidates" = "继续提供联想字词";
 "Always use the keyboard layout when Shift key is pressed" = "按下 Shift 时固定使用";
+"Use space as the first candidate key:" = "使用空白键选第一个候选字词：";
+"Disabled" = "不使用";
+"Original first key selects the second candidate" = "原本第一个选字键选第二个字词";
+"Both space and the first key selects the first candidate" = "空白键与原本第一个选字键都选第一个字词";

--- a/Source/Mac/zh-Hant.lproj/Localizable.strings
+++ b/Source/Mac/zh-Hant.lproj/Localizable.strings
@@ -143,3 +143,8 @@
 "After a candidate is chosen:" = "選完聯想字詞後：";
 "Keep showing new candidates" = "繼續提供聯想字詞";
 "Always use the keyboard layout when Shift key is pressed" = "按下 Shift 時固定使用";
+"Use space as the first candidate key:" = "使用空白鍵選第一個候選字詞：";
+"Disabled" = "不使用";
+"Original first key selects the second candidate" = "原本第一個選字鍵選第二個字詞";
+"Both space and the first key selects the first candidate" = "空白鍵與原本第一個選字鍵都選第一個字詞";
+


### PR DESCRIPTION
Currently we just simply insert the space key to the beginning of the candidate list. However, the users expect that they can use both space and the original first key to select the first candidate. This is for #30.