### PR TITLE
Implements the feature to use space as the first selection key for the associated phrases

### DIFF
--- a/Packages/OpenVanilla/Sources/LegacyOpenVanilla/include/LegacyOVFrameworkWrapper.h
+++ b/Packages/OpenVanilla/Sources/LegacyOpenVanilla/include/LegacyOVFrameworkWrapper.h
@@ -156,7 +156,8 @@ public:
             m_list->addCandidate(s.substr(2));
         }
 
-        m_panel->setCandidateKeys(candidateKeys, false, m_service);
+//        m_panel->setCandidateKeys(candidateKeys, false, m_service);
+        m_panel->setCandidateKeys(candidateKeys, m_service);
         m_panel->updateDisplay();
         return this;
     }

--- a/Packages/OpenVanilla/Sources/LegacyOpenVanilla/include/LegacyOVFrameworkWrapper.h
+++ b/Packages/OpenVanilla/Sources/LegacyOpenVanilla/include/LegacyOVFrameworkWrapper.h
@@ -156,7 +156,6 @@ public:
             m_list->addCandidate(s.substr(2));
         }
 
-//        m_panel->setCandidateKeys(candidateKeys, false, m_service);
         m_panel->setCandidateKeys(candidateKeys, m_service);
         m_panel->updateDisplay();
         return this;

--- a/Packages/OpenVanilla/Sources/OVAFAssociatedPhrases/OVAFAssociatedPhrases.cpp
+++ b/Packages/OpenVanilla/Sources/OVAFAssociatedPhrases/OVAFAssociatedPhrases.cpp
@@ -145,20 +145,20 @@ vector<pair<OVKey, string>> OVAFAssociatedPhrases::getSelectionKeyLabelPairs(OVL
         selectionKeys = string(" ") + selectionKeys;
     }
 
-    if (selectionKeys.length() <= strlen(kDefaultSelectionKeys) &&
-        string(kDefaultSelectionKeys, m_selectionKeys.length()) == m_selectionKeys) {
-        for (size_t i = 0, len = m_selectionKeys.length(); i < len; i++) {
-            keyLabelPairs.push_back(make_pair(loaderService->makeOVKey(m_selectionKeys[i]), m_shiftKeySymbol + string(1, kDefaultUnshiftedSelectionKeyLabels[i])));
-        }
-    } else {
-        for (const auto& key : selectionKeys) {
-            string label = string(1, key);
+    for (int i = 0; i < selectionKeys.size(); i++) {
+        string key = string(1, selectionKeys[i]);
+        string label = key;
+        if (i == 0 && m_configUseSpaceAsFirstCandidateSelectionKey == SpaceAndOriginalFirstKeySelectsFirstCandidate) {
+            label = "␣";
+        } else if (label == " ") {
+            label = "␣";
+        } else {
             string::size_type loc = string(kDefaultSelectionKeys).find(label, 0);
             if (loc != string::npos) {
                 label = m_shiftKeySymbol + string(1, kDefaultUnshiftedSelectionKeyLabels[loc]);
             }
-            keyLabelPairs.push_back(make_pair(loaderService->makeOVKey(key), label));
         }
+        keyLabelPairs.push_back(make_pair(loaderService->makeOVKey(key), label));
     }
     return keyLabelPairs;
 }

--- a/Packages/OpenVanilla/Sources/OVAFAssociatedPhrases/OVAFAssociatedPhrases.cpp
+++ b/Packages/OpenVanilla/Sources/OVAFAssociatedPhrases/OVAFAssociatedPhrases.cpp
@@ -95,6 +95,12 @@ void OVAFAssociatedPhrases::loadConfig(OVKeyValueMap* moduleConfig, OVLoaderServ
             m_shiftKeySymbol = symbol;
         }
     }
+    if (moduleConfig->hasKey("UseSpaceAsFirstCandidateSelectionKey")) {
+        m_configUseSpaceAsFirstCandidateSelectionKey = static_cast<UseSpaceAsFirstCandidateSelectionKeyOption>(moduleConfig->intValueForKey("UseSpaceAsFirstCandidateSelectionKey"));
+    }
+    if (moduleConfig->hasKey("SendFirstCandidateWithSpaceWithOnePageList")) {
+        m_configSendFirstCandidateWithSpaceWithOnePageList = moduleConfig->isKeyTrue("SendFirstCandidateWithSpaceWithOnePageList");
+    }
 }
 
 void OVAFAssociatedPhrases::saveConfig(OVKeyValueMap* moduleConfig, OVLoaderService* loaderService)
@@ -102,6 +108,8 @@ void OVAFAssociatedPhrases::saveConfig(OVKeyValueMap* moduleConfig, OVLoaderServ
     moduleConfig->setKeyBoolValue("ContinuousAssociation", m_continuousAssociation);
     moduleConfig->setKeyStringValue("SelectionKeys", m_selectionKeys);
     moduleConfig->setKeyStringValue("ShiftKeySymbol", m_shiftKeySymbol);
+    moduleConfig->setKeyBoolValue("SendFirstCandidateWithSpaceWithOnePageList", m_configSendFirstCandidateWithSpaceWithOnePageList);
+    moduleConfig->setKeyIntValue("UseSpaceAsFirstCandidateSelectionKey", m_configUseSpaceAsFirstCandidateSelectionKey);
 }
 
 void OVAFAssociatedPhrases::checkTable()

--- a/Packages/OpenVanilla/Sources/OVAFAssociatedPhrases/OVAFAssociatedPhrases.cpp
+++ b/Packages/OpenVanilla/Sources/OVAFAssociatedPhrases/OVAFAssociatedPhrases.cpp
@@ -140,14 +140,24 @@ void OVAFAssociatedPhrases::checkTable()
 vector<pair<OVKey, string>> OVAFAssociatedPhrases::getSelectionKeyLabelPairs(OVLoaderService* loaderService)
 {
     vector<pair<OVKey, string>> keyLabelPairs;
-    if (m_selectionKeys.length() <= strlen(kDefaultSelectionKeys) &&
+    string selectionKeys = m_selectionKeys;
+    if (m_configUseSpaceAsFirstCandidateSelectionKey == OriginalFirstKeySelectsSecondCandidate) {
+        selectionKeys = string(" ") + selectionKeys;
+    }
+
+    if (selectionKeys.length() <= strlen(kDefaultSelectionKeys) &&
         string(kDefaultSelectionKeys, m_selectionKeys.length()) == m_selectionKeys) {
         for (size_t i = 0, len = m_selectionKeys.length(); i < len; i++) {
             keyLabelPairs.push_back(make_pair(loaderService->makeOVKey(m_selectionKeys[i]), m_shiftKeySymbol + string(1, kDefaultUnshiftedSelectionKeyLabels[i])));
         }
     } else {
-        for (const auto& key : m_selectionKeys) {
-            keyLabelPairs.push_back(make_pair(loaderService->makeOVKey(key), string(1, key)));
+        for (const auto& key : selectionKeys) {
+            string label = string(1, key);
+            string::size_type loc = string(kDefaultSelectionKeys).find(label, 0);
+            if (loc != string::npos) {
+                label = m_shiftKeySymbol + string(1, kDefaultUnshiftedSelectionKeyLabels[loc]);
+            }
+            keyLabelPairs.push_back(make_pair(loaderService->makeOVKey(key), label));
         }
     }
     return keyLabelPairs;

--- a/Packages/OpenVanilla/Sources/OVAFAssociatedPhrases/OVAFAssociatedPhrasesContext.cpp
+++ b/Packages/OpenVanilla/Sources/OVAFAssociatedPhrases/OVAFAssociatedPhrasesContext.cpp
@@ -66,10 +66,15 @@ bool OVAFAssociatedPhrasesContext::handleKey(OVKey* key, OVTextBuffer* readingTe
 		  
     bool keyHandled = false;
     size_t keyIndex;
-    size_t selKeyLength = m_module->m_selectionKeys.length();
+    string candidateKeys = m_module->m_selectionKeys;
+    size_t selKeyLength = candidateKeys.length();
+
+    if (m_module->m_configUseSpaceAsFirstCandidateSelectionKey == OriginalFirstKeySelectsSecondCandidate) {
+        candidateKeys = string(" ") + candidateKeys;
+    }
 
     for (keyIndex = 0; keyIndex < selKeyLength; keyIndex++) {
-        if (key->keyCode() == m_module->m_selectionKeys[keyIndex]) break;
+        if (key->keyCode() == candidateKeys[keyIndex]) break;
     }
 
     if (keyIndex < selKeyLength) {

--- a/Packages/OpenVanilla/Sources/OVAFAssociatedPhrases/OVAFAssociatedPhrasesContext.cpp
+++ b/Packages/OpenVanilla/Sources/OVAFAssociatedPhrases/OVAFAssociatedPhrasesContext.cpp
@@ -58,23 +58,34 @@ bool OVAFAssociatedPhrasesContext::handleKey(OVKey* key, OVTextBuffer* readingTe
         return true;
     }
     
-    if (key->keyCode() == OVKeyCode::PageDown || key->keyCode() == OVKeyCode::Space) {
+    if (key->keyCode() == OVKeyCode::PageDown ||
+        (key->keyCode() == OVKeyCode::Space &&
+         m_module->m_configUseSpaceAsFirstCandidateSelectionKey == Disabled)) {
         panel->goToNextPage();
         panel->updateDisplay();
         return true;
     }
 		  
     bool keyHandled = false;
-    size_t keyIndex;
-    string candidateKeys = m_module->m_selectionKeys;
-    size_t selKeyLength = candidateKeys.length();
+
+    string selectionKeys = m_module->m_selectionKeys;
 
     if (m_module->m_configUseSpaceAsFirstCandidateSelectionKey == OriginalFirstKeySelectsSecondCandidate) {
-        candidateKeys = string(" ") + candidateKeys;
+        selectionKeys = string(" ") + selectionKeys;
     }
 
-    for (keyIndex = 0; keyIndex < selKeyLength; keyIndex++) {
-        if (key->keyCode() == candidateKeys[keyIndex]) break;
+    size_t selKeyLength = selectionKeys.length();
+    size_t keyIndex = selKeyLength;
+    if (key->keyCode() == OVKeyCode::Space) {
+        if (m_module->m_configUseSpaceAsFirstCandidateSelectionKey == OriginalFirstKeySelectsSecondCandidate ||
+            m_module->m_configUseSpaceAsFirstCandidateSelectionKey == SpaceAndOriginalFirstKeySelectsFirstCandidate
+            ) {
+            keyIndex = 0;
+        }
+    } else {
+        for (keyIndex = 0; keyIndex < selKeyLength; keyIndex++) {
+            if (key->keyCode() == selectionKeys[keyIndex]) break;
+        }
     }
 
     if (keyIndex < selKeyLength) {

--- a/Packages/OpenVanilla/Sources/OVAFAssociatedPhrases/OVAFAssociatedPhrasesContext.cpp
+++ b/Packages/OpenVanilla/Sources/OVAFAssociatedPhrases/OVAFAssociatedPhrasesContext.cpp
@@ -57,10 +57,8 @@ bool OVAFAssociatedPhrasesContext::handleKey(OVKey* key, OVTextBuffer* readingTe
         panel->updateDisplay();
         return true;
     }
-    
-    if (key->keyCode() == OVKeyCode::PageDown ||
-        (key->keyCode() == OVKeyCode::Space &&
-         m_module->m_configUseSpaceAsFirstCandidateSelectionKey == Disabled)) {
+
+    if (key->keyCode() == OVKeyCode::PageDown) {
         panel->goToNextPage();
         panel->updateDisplay();
         return true;
@@ -77,6 +75,17 @@ bool OVAFAssociatedPhrasesContext::handleKey(OVKey* key, OVTextBuffer* readingTe
     size_t selKeyLength = selectionKeys.length();
     size_t keyIndex = selKeyLength;
     if (key->keyCode() == OVKeyCode::Space) {
+        if (m_module->m_configUseSpaceAsFirstCandidateSelectionKey == Disabled) {
+            if (m_module->m_configSendFirstCandidateWithSpaceWithOnePageList) {
+                if (m_candidates.size() <= selKeyLength) {
+                    keyIndex = 0;
+                }
+            } else {
+                panel->goToNextPage();
+                panel->updateDisplay();
+                return true;
+            }
+        }
         if (m_module->m_configUseSpaceAsFirstCandidateSelectionKey == OriginalFirstKeySelectsSecondCandidate ||
             m_module->m_configUseSpaceAsFirstCandidateSelectionKey == SpaceAndOriginalFirstKeySelectsFirstCandidate
             ) {

--- a/Packages/OpenVanilla/Sources/OVAFAssociatedPhrases/include/OVAFAssociatedPhrases.h
+++ b/Packages/OpenVanilla/Sources/OVAFAssociatedPhrases/include/OVAFAssociatedPhrases.h
@@ -34,6 +34,12 @@
 namespace OpenVanilla {
     using namespace std;
 
+    enum UseSpaceAsFirstCandidateSelectionKeyOption {
+        Disabled,
+        OriginalFirstKeySelectsSecondCandidate,
+        SpaceAndOriginalFirstKeySelectsFirstCandidate,
+    };
+
     class OVAFAssociatedPhrasesContext;
 
     class OVAFAssociatedPhrases : public OVAroundFilter {
@@ -58,6 +64,9 @@ namespace OpenVanilla {
         OVCINDataTable *m_table;
         bool m_continuousAssociation; // Use the output of this filter as the next input.
         string m_selectionKeys; // The actual selection keys.
+        UseSpaceAsFirstCandidateSelectionKeyOption m_configUseSpaceAsFirstCandidateSelectionKey;
+        bool m_configSendFirstCandidateWithSpaceWithOnePageList;
+
         vector<pair<OVKey, string>> getSelectionKeyLabelPairs(OVLoaderService* loaderService);
     };
 };

--- a/Packages/OpenVanilla/Sources/OVAFAssociatedPhrases/include/OVAFAssociatedPhrasesContext.h
+++ b/Packages/OpenVanilla/Sources/OVAFAssociatedPhrases/include/OVAFAssociatedPhrasesContext.h
@@ -46,6 +46,7 @@ namespace OpenVanilla {
 		OVAFAssociatedPhrases* m_module;
         vector<string> m_candidates;
         string m_lastOutput;
+
     };
 };
 

--- a/Packages/OpenVanilla/Sources/OVIMBig5Code/include/OVIMBig5Code.h
+++ b/Packages/OpenVanilla/Sources/OVIMBig5Code/include/OVIMBig5Code.h
@@ -7,7 +7,7 @@
 namespace OpenVanilla {
     using namespace std;
 
-    class OVIMArrayContext;
+    class OVIMBig5CodeContext;
 
     class OVIMBig5Code : public OVInputMethod {
     public:

--- a/Packages/OpenVanilla/Sources/OVIMBig5Code/include/OVIMBig5CodeContext.h
+++ b/Packages/OpenVanilla/Sources/OVIMBig5Code/include/OVIMBig5CodeContext.h
@@ -1,4 +1,3 @@
-
 #ifndef OVIMBig5CodeContext_h
 #define OVIMBig5CodeContext_h
 

--- a/Packages/OpenVanilla/Sources/OVIMTableBased/OVIMTableBasedContext.cpp
+++ b/Packages/OpenVanilla/Sources/OVIMTableBased/OVIMTableBasedContext.cpp
@@ -239,7 +239,9 @@ bool OVIMTableBasedContext::candidateNonPanelKeyReceived(OVCandidateService* can
     }
 
     if (key->keyCode() == OVKeyCode::Space) {
-        if (m_module->m_configSendFirstCandidateWithSpaceWithOnePageList) {
+        if (
+            m_module->m_configUseSpaceAsFirstCandidateSelectionKey == SpaceAndOriginalFirstKeySelectsFirstCandidate ||
+            m_module->m_configSendFirstCandidateWithSpaceWithOnePageList) {
             panel->hide();
             panel->cancelEventHandler();
             string text = panel->candidateList()->candidateAtIndex(0);
@@ -452,10 +454,22 @@ bool OVIMTableBasedContext::compose(OVTextBuffer* readingText, OVTextBuffer* com
             candidateKeys = candidateKeys.substr(0, results.size());
         }
 
-        panel->setCandidateKeys(candidateKeys, m_module->m_configUseSpaceAsFirstCandidateSelectionKey == SpaceAndOriginalFirstKeySelectsFirstCandidate, loaderService);
+        vector<pair<OVKey, string>> keyLabelPairs;
+        for (int i = 0; i < candidateKeys.size(); i++) {
+            string key = string(1, candidateKeys[i]);
+            string label = key;
+            if (i == 0 && m_module->m_configUseSpaceAsFirstCandidateSelectionKey == SpaceAndOriginalFirstKeySelectsFirstCandidate) {
+                label = "␣";
+            } else if (label == " ") {
+                label = "␣";
+            }
+            keyLabelPairs.push_back(make_pair(loaderService->makeOVKey(key), label));
+        }
+        panel->setCandidateKeysAndLabels(keyLabelPairs);
 
         OVKeyVector nextPageKeys;
-        if (results.size() <= candidateKeys.length() && (m_module->m_configUseSpaceAsFirstCandidateSelectionKey || m_module->m_configSendFirstCandidateWithSpaceWithOnePageList)) {
+        if (results.size() <= candidateKeys.length() &&
+            (m_module->m_configUseSpaceAsFirstCandidateSelectionKey || m_module->m_configSendFirstCandidateWithSpaceWithOnePageList)) {
             OVKeyVector v = panel->defaultNextPageKeys();
             OVKey spaceKey = loaderService->makeOVKey(OVKeyCode::Space, false, false, false, false, false, false, false);
             for (OVKeyVector::const_iterator i = v.begin(), e = v.end(); i != e; ++i) {

--- a/Packages/OpenVanilla/Sources/OVIMTableBased/OVIMTableBasedContext.cpp
+++ b/Packages/OpenVanilla/Sources/OVIMTableBased/OVIMTableBasedContext.cpp
@@ -468,8 +468,9 @@ bool OVIMTableBasedContext::compose(OVTextBuffer* readingText, OVTextBuffer* com
         panel->setCandidateKeysAndLabels(keyLabelPairs);
 
         OVKeyVector nextPageKeys;
-        if (results.size() <= candidateKeys.length() &&
-            (m_module->m_configUseSpaceAsFirstCandidateSelectionKey || m_module->m_configSendFirstCandidateWithSpaceWithOnePageList)) {
+        if  (m_module->m_configUseSpaceAsFirstCandidateSelectionKey == OriginalFirstKeySelectsSecondCandidate ||
+             m_module->m_configUseSpaceAsFirstCandidateSelectionKey == SpaceAndOriginalFirstKeySelectsFirstCandidate ||
+             (results.size() <= candidateKeys.length() && m_module->m_configSendFirstCandidateWithSpaceWithOnePageList)) {
             OVKeyVector v = panel->defaultNextPageKeys();
             OVKey spaceKey = loaderService->makeOVKey(OVKeyCode::Space, false, false, false, false, false, false, false);
             for (OVKeyVector::const_iterator i = v.begin(), e = v.end(); i != e; ++i) {

--- a/Packages/OpenVanilla/Sources/OVIMTableBased/include/OVIMTableBased.h
+++ b/Packages/OpenVanilla/Sources/OVIMTableBased/include/OVIMTableBased.h
@@ -72,9 +72,9 @@ namespace OpenVanilla {
         char m_configMatchOneChar;
         char m_configMatchZeroOrMoreChar;
         size_t m_configMaximumRadicalLength;
-        bool m_configSendFirstCandidateWithSpaceWithOnePageList;
         bool m_configShouldComposeAtMaximumRadicalLength;
         UseSpaceAsFirstCandidateSelectionKeyOption m_configUseSpaceAsFirstCandidateSelectionKey;
+        bool m_configSendFirstCandidateWithSpaceWithOnePageList;
         bool m_configOnlyUseNumPadNumbersForRadicals;
         bool m_specialCodePrompt;
     };

--- a/Packages/OpenVanilla/Sources/OpenVanilla/include/OVCandidateService.h
+++ b/Packages/OpenVanilla/Sources/OpenVanilla/include/OVCandidateService.h
@@ -118,14 +118,13 @@ namespace OpenVanilla {
         virtual size_t goToPage(size_t page) = 0;
 
         virtual const OVKey candidateKeyAtIndex(size_t index) = 0;
-        virtual void setCandidateKeys(const string& asciiKeys, bool useSpaceAsFirstCandidateSelectionKey, OVLoaderService* loaderService)
+        virtual void setCandidateKeys(const string& asciiKeys, OVLoaderService* loaderService)
         {
             OVKeyVector keys;
             for (size_t index = 0; index < asciiKeys.length(); index++) {
                 keys.push_back(loaderService->makeOVKey(asciiKeys[index]));
             }
 
-            m_useSpaceAsFirstCandidateSelectionKey = useSpaceAsFirstCandidateSelectionKey;
             setCandidateKeys(keys);
             setCandidatesPerPage(asciiKeys.length());
         }
@@ -147,9 +146,6 @@ namespace OpenVanilla {
         virtual const OVKeyVector defaultChooseHighlightedCandidateKeys() const = 0;
 
         virtual void setCandidateKeysAndLabels(const vector<pair<OVKey, string> >& keyLabelPairs) = 0;
-        virtual const bool useSpaceAsFirstCandidateSelectionKey() {
-            return m_useSpaceAsFirstCandidateSelectionKey;
-        }
 
     private:
         bool m_useSpaceAsFirstCandidateSelectionKey = false;

--- a/Packages/OpenVanilla/Sources/OpenVanillaImpl/OVOneDimensionalCandidatePanelImpl.mm
+++ b/Packages/OpenVanilla/Sources/OpenVanillaImpl/OVOneDimensionalCandidatePanelImpl.mm
@@ -362,17 +362,7 @@ void OVOneDimensionalCandidatePanelImpl::setCandidateKeys(const OVKeyVector& key
     for (OVKeyVector::const_iterator i = keys.begin(), e = keys.end(); i != e; ++i) {
         NSString *key = nil;
         NSString *diaplayedText = nil;
-        if (i == keys.begin() && useSpaceAsFirstCandidateSelectionKey()) {
-            key = @" ";
-            diaplayedText = @"␣";
-        } else {
-            key = @((*i).receivedString().c_str());
-            if ([key isEqualToString:@" "]) {
-                diaplayedText = @"␣";
-            } else {
-                diaplayedText = key;
-            }
-        }
+        key = @((*i).receivedString().c_str());
         VTCandidateKeyLabel *label = [[VTCandidateKeyLabel alloc] initWithKey:key displayedText:diaplayedText];
         [labels addObject:label];
     }
@@ -454,12 +444,13 @@ OVOneDimensionalCandidatePanelImpl::KeyHandlerResult OVOneDimensionalCandidatePa
 {
     size_t selectedCandidateKeyIndex;
 
-    if (useSpaceAsFirstCandidateSelectionKey() && IsKeyInList(key, m_spaceKeys)) {
-        hide();
-        m_inControl = false;
-        setHighlightIndex(0);
-        return CandidateSelected;
-    } else if (IsKeyInList(key, m_candidateKeys, &selectedCandidateKeyIndex)) {
+//    if (useSpaceAsFirstCandidateSelectionKey() && IsKeyInList(key, m_spaceKeys)) {
+//        hide();
+//        m_inControl = false;
+//        setHighlightIndex(0);
+//        return CandidateSelected;
+//    } else
+    if (IsKeyInList(key, m_candidateKeys, &selectedCandidateKeyIndex)) {
         if (selectedCandidateKeyIndex >= currentPageCandidateCount()) {
             return Invalid;
         }

--- a/Packages/OpenVanilla/Sources/OpenVanillaImpl/include/OVOneDimensionalCandidatePanelImpl.h
+++ b/Packages/OpenVanilla/Sources/OpenVanillaImpl/include/OVOneDimensionalCandidatePanelImpl.h
@@ -105,7 +105,6 @@ namespace OpenVanilla {
         virtual void setPanelOrigin(NSPoint origin, CGFloat adjustmentHeight);
         virtual void updateVisibility();
         virtual void applyFontSettings(NSString *fontName = nil, NSUInteger fontSize = 0);
-
         virtual void setCandidateKeysAndLabels(const vector<pair<OVKey, string>>& keyLabelPairs);
 
     protected:

--- a/Source/Mac/Preferences/AssociatedPhrasesPreferencesViewController.swift
+++ b/Source/Mac/Preferences/AssociatedPhrasesPreferencesViewController.swift
@@ -35,11 +35,11 @@ class AssociatedPhrasesPreferencesViewController: BaseModulePreferencesViewContr
     @IBOutlet weak var fieldUseSpaceAsFirstCandidateSelectionKey: NSMatrix!
     @IBOutlet weak var fieldSendFirstCandidateWithSpaceWithOnePageList: NSButton!
 
-    private var defaultSelectionKeys: [String] = [
-        "!#$%^&*()", "!#$%^&*(", "1234567890", "123456789",
-    ]
-    private var defaultSelectionKeyTitles: [String] = [
-        "Shift-1 ~ Shift-0", "Shift-1 ~ Shift-9", "1234567890", "123456789",
+    private let defaultSelectionKeys: [(String, String)] = [
+        ("!@#$%^&*()", "Shift-1 ~ Shift-0"),
+        ("!@#$%^&*(", "Shift-1 ~ Shift-9"),
+        ("1234567890", "1234567890"),
+        ("123456789", "1234567890"),
     ]
 
     required init?(coder: NSCoder) {
@@ -60,21 +60,24 @@ class AssociatedPhrasesPreferencesViewController: BaseModulePreferencesViewContr
         }
         let selectedIndex: Int? = {
             if !selectionKeys.isEmpty {
-                return defaultSelectionKeys.firstIndex(of: selectionKeys)
+                return defaultSelectionKeys.firstIndex { value, title in
+                    value == selectionKeys
+                }
             }
             return nil
         }()
 
-        guard let selectedIndex = selectedIndex else {
-            var titles = defaultSelectionKeyTitles
+        if let selectedIndex = selectedIndex {
+            fieldSelectionKeys.addItems(withTitles: defaultSelectionKeys.map { $1 })
+            fieldSelectionKeys.selectItem(at: selectedIndex)
+        } else  {
+            var titles = defaultSelectionKeys.map { $1 }
             titles.append(selectionKeys)
             fieldSelectionKeys.addItems(withTitles: titles)
             fieldSelectionKeys.selectItem(at: titles.count - 1)
             return
         }
 
-        fieldSelectionKeys.addItems(withTitles: defaultSelectionKeyTitles)
-        fieldSelectionKeys.selectItem(at: selectedIndex)
         setState(for: self.fieldContinuousAssociation, key: "ContinuousAssociation")
 
         let useSpaceAsFirstCandidateSelectionKey =
@@ -110,8 +113,9 @@ class AssociatedPhrasesPreferencesViewController: BaseModulePreferencesViewContr
             selectedIndex = 0
         }
         let newSelectionKeys =
-            (selectedIndex < defaultSelectionKeyTitles.count
-            ? defaultSelectionKeys : defaultSelectionKeyTitles)[selectedIndex]
+            (selectedIndex < defaultSelectionKeys.count)
+                ? defaultSelectionKeys[selectedIndex].0 :
+                (fieldSelectionKeys.selectedItem?.title ?? defaultSelectionKeys[0].0)
         setStringValue(newSelectionKeys, forKey: "SelectionKeys")
         setUnsignedIntegerValue(
             UInt(fieldUseSpaceAsFirstCandidateSelectionKey.selectedCell()?.tag ?? 0),

--- a/Source/Mac/Preferences/AssociatedPhrasesPreferencesViewController.swift
+++ b/Source/Mac/Preferences/AssociatedPhrasesPreferencesViewController.swift
@@ -32,6 +32,8 @@ class AssociatedPhrasesPreferencesViewController: BaseModulePreferencesViewContr
 
     @IBOutlet weak var fieldSelectionKeys: NSPopUpButton!
     @IBOutlet weak var fieldContinuousAssociation: NSButton!
+    @IBOutlet weak var fieldUseSpaceAsFirstCandidateSelectionKey: NSMatrix!
+    @IBOutlet weak var fieldSendFirstCandidateWithSpaceWithOnePageList: NSButton!
 
     private var defaultSelectionKeys: [String] = [
         "!#$%^&*()", "!#$%^&*(", "1234567890", "123456789",
@@ -74,9 +76,34 @@ class AssociatedPhrasesPreferencesViewController: BaseModulePreferencesViewContr
         fieldSelectionKeys.addItems(withTitles: defaultSelectionKeyTitles)
         fieldSelectionKeys.selectItem(at: selectedIndex)
         setState(for: self.fieldContinuousAssociation, key: "ContinuousAssociation")
+
+        let useSpaceAsFirstCandidateSelectionKey =
+            unsignedIntegerValue(forKey: "UseSpaceAsFirstCandidateSelectionKey") ?? 0
+
+        if useSpaceAsFirstCandidateSelectionKey != 0 {
+            fieldUseSpaceAsFirstCandidateSelectionKey.selectCell(withTag: Int(
+                useSpaceAsFirstCandidateSelectionKey))
+            fieldSendFirstCandidateWithSpaceWithOnePageList.state = .off
+        } else if boolValue(forKey: "SendFirstCandidateWithSpaceWithOnePageList") {
+            fieldUseSpaceAsFirstCandidateSelectionKey.selectCell(withTag: 0)
+            fieldSendFirstCandidateWithSpaceWithOnePageList.state = .on
+        } else {
+            fieldUseSpaceAsFirstCandidateSelectionKey.selectCell(withTag: 0)
+            fieldSendFirstCandidateWithSpaceWithOnePageList.state = .off
+        }
     }
 
-    @IBAction func updateField(_ sender: Any?) {
+    @IBAction func updateField(_ sender: NSObject?) {
+        if sender == fieldUseSpaceAsFirstCandidateSelectionKey {
+            if fieldUseSpaceAsFirstCandidateSelectionKey.selectedCell()?.tag ?? 0 != 0 {
+                fieldSendFirstCandidateWithSpaceWithOnePageList.state = .off
+            }
+        } else if sender == fieldSendFirstCandidateWithSpaceWithOnePageList {
+            if fieldSendFirstCandidateWithSpaceWithOnePageList.state == .on {
+                fieldUseSpaceAsFirstCandidateSelectionKey.selectCell(withTag: 0)
+            }
+        }
+
         setBoolValue(self.fieldContinuousAssociation.state == .on, forKey: "ContinuousAssociation")
         var selectedIndex = self.fieldSelectionKeys.indexOfSelectedItem
         if selectedIndex == -1 {
@@ -86,5 +113,11 @@ class AssociatedPhrasesPreferencesViewController: BaseModulePreferencesViewContr
             (selectedIndex < defaultSelectionKeyTitles.count
             ? defaultSelectionKeys : defaultSelectionKeyTitles)[selectedIndex]
         setStringValue(newSelectionKeys, forKey: "SelectionKeys")
+        setUnsignedIntegerValue(
+            UInt(fieldUseSpaceAsFirstCandidateSelectionKey.selectedCell()?.tag ?? 0),
+            forKey: "UseSpaceAsFirstCandidateSelectionKey")
+        setBoolValue(
+            fieldSendFirstCandidateWithSpaceWithOnePageList.state == .on,
+            forKey: "SendFirstCandidateWithSpaceWithOnePageList")
     }
 }

--- a/Source/Mac/Preferences/AssociatedPhrasesPreferencesViewController.swift
+++ b/Source/Mac/Preferences/AssociatedPhrasesPreferencesViewController.swift
@@ -39,7 +39,7 @@ class AssociatedPhrasesPreferencesViewController: BaseModulePreferencesViewContr
         ("!@#$%^&*()", "Shift-1 ~ Shift-0"),
         ("!@#$%^&*(", "Shift-1 ~ Shift-9"),
         ("1234567890", "1234567890"),
-        ("123456789", "1234567890"),
+        ("123456789", "123456789"),
     ]
 
     required init?(coder: NSCoder) {

--- a/Source/Mac/Preferences/TableBasedModulePreferencesViewController.swift
+++ b/Source/Mac/Preferences/TableBasedModulePreferencesViewController.swift
@@ -30,16 +30,16 @@ import OpenVanillaImpl
 @objc(OVTableBasedModulePreferencesViewController)
 class TableBasedModulePreferencesViewController: BaseModulePreferencesViewController {
 
-    @IBOutlet var fieldAlphaNumericKeyboardLayout: NSPopUpButton!
-    @IBOutlet var fieldMaximumRadicalLength: NSPopUpButton!
-    @IBOutlet var fieldClearReadingBufferAtCompositionError: NSButton!
-    @IBOutlet var fieldComposeWhileTyping: NSButton!
-    @IBOutlet var fieldSendFirstCandidateWithSpaceWithOnePageList: NSButton!
-    @IBOutlet var fieldShouldComposeAtMaximumRadicalLength: NSButton!
-    @IBOutlet var fieldUseSpaceAsFirstCandidateSelectionKey: NSMatrix!
-    @IBOutlet var fieldSpecialCodePrompt: NSButton!
-    @IBOutlet var customTableBasedInputMethodInfo: NSTextField!
-    @IBOutlet var removeInputMethodButton: NSButton!
+    @IBOutlet weak var fieldAlphaNumericKeyboardLayout: NSPopUpButton!
+    @IBOutlet weak var fieldMaximumRadicalLength: NSPopUpButton!
+    @IBOutlet weak var fieldClearReadingBufferAtCompositionError: NSButton!
+    @IBOutlet weak var fieldComposeWhileTyping: NSButton!
+    @IBOutlet weak var fieldSendFirstCandidateWithSpaceWithOnePageList: NSButton!
+    @IBOutlet weak var fieldShouldComposeAtMaximumRadicalLength: NSButton!
+    @IBOutlet weak var fieldUseSpaceAsFirstCandidateSelectionKey: NSMatrix!
+    @IBOutlet weak var fieldSpecialCodePrompt: NSButton!
+    @IBOutlet weak var customTableBasedInputMethodInfo: NSTextField!
+    @IBOutlet weak var removeInputMethodButton: NSButton!
 
     override var moduleIdentifier: String! {
         didSet {

--- a/Source/Mac/preferences.xib
+++ b/Source/Mac/preferences.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23094" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23504" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23094"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23504"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -122,7 +122,7 @@
                         <action selector="updateField:" target="69" id="95"/>
                     </connections>
                 </button>
-                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="75">
+                <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="75">
                     <rect key="frame" x="17" y="327" width="233" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Maximum component buffer length:" id="76">
@@ -164,7 +164,7 @@
                         <action selector="updateField:" target="69" id="92"/>
                     </connections>
                 </popUpButton>
-                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="124">
+                <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="124">
                     <rect key="frame" x="17" y="293" width="233" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Alphanumeric keyboard layout:" id="131">
@@ -202,7 +202,7 @@
                         <action selector="removeInputMethodAction:" target="69" id="176"/>
                     </connections>
                 </button>
-                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="134">
+                <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="134">
                     <rect key="frame" x="17" y="22" width="232" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="This is a customized input method." id="135">
@@ -226,7 +226,7 @@
                     <rect key="frame" x="19" y="186" width="401" height="5"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                 </box>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="d1h-Gp-njO">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="d1h-Gp-njO">
                     <rect key="frame" x="18" y="164" width="227" height="16"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="Use space as the first candidate key:" id="VMK-sQ-0rx">
@@ -321,7 +321,7 @@
                         <action selector="updateField:" target="70" id="161"/>
                     </connections>
                 </popUpButton>
-                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="28">
+                <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="28">
                     <rect key="frame" x="36" y="326" width="182" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Candidate list font size:" id="29">
@@ -330,7 +330,7 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="52">
+                <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="52">
                     <rect key="frame" x="36" y="301" width="182" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Candidate list style:" id="53">
@@ -339,7 +339,7 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="114">
+                <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="114">
                     <rect key="frame" x="36" y="198" width="182" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Feedback:" id="115">
@@ -348,7 +348,7 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="116">
+                <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="116">
                     <rect key="frame" x="36" y="73" width="182" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Update Check:" id="117">
@@ -357,7 +357,7 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="44">
+                <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="44">
                     <rect key="frame" x="17" y="254" width="201" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Alphanumeric keyboard layout:" id="45">
@@ -443,7 +443,7 @@
                         <action selector="checkForUpdateAction:" target="70" id="160"/>
                     </connections>
                 </button>
-                <textField hidden="YES" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="122">
+                <textField hidden="YES" focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="122">
                     <rect key="frame" x="220" y="20" width="203" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Last checked: December 31, 2011" id="123">
@@ -523,7 +523,7 @@
                         <action selector="importNewTableAction:" target="168" id="173"/>
                     </connections>
                 </button>
-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="141">
+                <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="141">
                     <rect key="frame" x="71" y="286" width="289" height="34"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="Create a customized input method by importing a .cin file" id="142">
@@ -532,7 +532,7 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="143">
+                <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="143">
                     <rect key="frame" x="114" y="179" width="212" height="34"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="For more information, visit http://openvanilla.org" id="144">
@@ -548,7 +548,7 @@
             <rect key="frame" x="0.0" y="0.0" width="440" height="364"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="U7e-Qz-w2m">
+                <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="U7e-Qz-w2m">
                     <rect key="frame" x="-2" y="325" width="233" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Alphanumeric keyboard layout:" id="g9u-AH-pAp">
@@ -622,7 +622,7 @@
                         <action selector="updateField:" target="OTa-5M-Vdi" id="fhY-JS-3Uk"/>
                     </connections>
                 </popUpButton>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Bls-0d-kSy">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Bls-0d-kSy">
                     <rect key="frame" x="18" y="325" width="182" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Selection keys:" id="zVd-rT-Z8z">
@@ -631,7 +631,7 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uqx-6g-kZ1">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uqx-6g-kZ1">
                     <rect key="frame" x="18" y="301" width="182" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="After a candidate is chosen:" id="gXZ-4Y-ES9">
@@ -655,7 +655,7 @@
                     <rect key="frame" x="20" y="289" width="401" height="5"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                 </box>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xWi-LO-wHK">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xWi-LO-wHK">
                     <rect key="frame" x="19" y="267" width="227" height="16"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="Use space as the first candidate key:" id="741-Tl-FIB">

--- a/Source/Mac/preferences.xib
+++ b/Source/Mac/preferences.xib
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23094" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
+        <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23094"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -35,7 +36,7 @@
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <clipView key="contentView" id="APL-TT-LOB">
                             <rect key="frame" x="1" y="1" width="198" height="361"/>
-                            <autoresizingMask key="autoresizingMask"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" id="4">
                                     <rect key="frame" x="0.0" y="0.0" width="198" height="361"/>
@@ -650,6 +651,60 @@
                         <action selector="updateField:" target="OTa-5M-Vdi" id="Zma-W9-De4"/>
                     </connections>
                 </button>
+                <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="ejo-nt-pLH">
+                    <rect key="frame" x="20" y="289" width="401" height="5"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                </box>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xWi-LO-wHK">
+                    <rect key="frame" x="19" y="267" width="227" height="16"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" lineBreakMode="clipping" title="Use space as the first candidate key:" id="741-Tl-FIB">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <matrix verticalHuggingPriority="750" verticalCompressionResistancePriority="741" fixedFrame="YES" allowsEmptySelection="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gTR-U1-kBZ">
+                    <rect key="frame" x="21" y="194" width="387" height="64"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    <size key="cellSize" width="387" height="20"/>
+                    <size key="intercellSpacing" width="4" height="2"/>
+                    <buttonCell key="prototype" type="radio" title="Radio" imagePosition="left" alignment="left" inset="2" id="snZ-uD-BNQ">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <cells>
+                        <column>
+                            <buttonCell type="radio" title="Disabled" imagePosition="left" alignment="left" state="on" inset="2" id="9h4-WO-M0c">
+                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                <font key="font" metaFont="system"/>
+                            </buttonCell>
+                            <buttonCell type="radio" title="Original first key selects the second candidate" imagePosition="left" alignment="left" tag="1" inset="2" id="5GI-Jo-duf">
+                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                <font key="font" metaFont="system"/>
+                            </buttonCell>
+                            <buttonCell type="radio" title="Both space and the first key selects the first candidate" imagePosition="left" alignment="left" tag="2" inset="2" id="D6A-kN-xDH">
+                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                <font key="font" metaFont="system"/>
+                            </buttonCell>
+                        </column>
+                    </cells>
+                    <connections>
+                        <action selector="updateField:" target="OTa-5M-Vdi" id="aYx-7v-7Wl"/>
+                    </connections>
+                </matrix>
+                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3TC-RO-K1L">
+                    <rect key="frame" x="20" y="169" width="402" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="check" title="Space selects the first candidate when there's only one page" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Tu8-mP-oBb">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="updateField:" target="OTa-5M-Vdi" id="ieF-3B-lGb"/>
+                    </connections>
+                </button>
             </subviews>
             <point key="canvasLocation" x="-683" y="449"/>
         </customView>
@@ -657,6 +712,8 @@
             <connections>
                 <outlet property="fieldContinuousAssociation" destination="awe-EY-NXM" id="MF9-dT-18S"/>
                 <outlet property="fieldSelectionKeys" destination="WVL-Wd-oMk" id="g20-qv-HZl"/>
+                <outlet property="fieldSendFirstCandidateWithSpaceWithOnePageList" destination="3TC-RO-K1L" id="538-U9-Mz1"/>
+                <outlet property="fieldUseSpaceAsFirstCandidateSelectionKey" destination="gTR-U1-kBZ" id="nu7-Xr-2Kj"/>
                 <outlet property="view" destination="Sdw-aj-CtP" id="cHY-y9-i5i"/>
             </connections>
         </viewController>


### PR DESCRIPTION
The pull request addresses issues #90 and #91.

The PR updates the UI of the preference window, enabling users to select the space key as the first candidate key, akin to table-based input methods. In implementing this feature, I relocated the code that displays the space key as a candidate from the OpenVanilla framework scope to the module scope. This change simplifies and enhances the readability of the code within the framework scope.

The PR also updates the section to match special characters from !@#$%^&*( to the displayed text "Shift + 1" through "Shift + 0" as the candidate keys for the associated phrases.