### PR TITLE
Fix a number of bugs in the Swift version update check mechanism and improve the manual check logic

### DIFF
--- a/Source/Mac/NonModalAlertWindowController.swift
+++ b/Source/Mac/NonModalAlertWindowController.swift
@@ -23,15 +23,14 @@
 
 import Cocoa
 
-@objc protocol NonModalAlertWindowControllerDelegate {
+@objc protocol NonModalAlertWindowControllerDelegate: AnyObject {
     func nonModalAlertWindowControllerDidConfirm(_ controller: NonModalAlertWindowController)
     func nonModalAlertWindowControllerDidCancel(_ controller: NonModalAlertWindowController)
 }
 
 class NonModalAlertWindowController: NSWindowController {
     @objc(sharedInstance)
-    static let shared = NonModalAlertWindowController(
-        windowNibName: "NonModalAlertWindowController")
+    static let shared = NonModalAlertWindowController(windowNibName: "NonModalAlertWindowController")
 
     @IBOutlet weak var titleTextField: NSTextField!
     @IBOutlet weak var contentTextField: NSTextField!
@@ -39,10 +38,7 @@ class NonModalAlertWindowController: NSWindowController {
     @IBOutlet weak var cancelButton: NSButton!
     weak var delegate: NonModalAlertWindowControllerDelegate?
 
-    @objc func show(
-        title: String, content: String, confirmButtonTitle: String, cancelButtonTitle: String?,
-        cancelAsDefault: Bool, delegate: NonModalAlertWindowControllerDelegate?
-    ) {
+    @objc func show(title: String, content: String, confirmButtonTitle: String, cancelButtonTitle: String?, cancelAsDefault: Bool, delegate: NonModalAlertWindowControllerDelegate?) {
         if window?.isVisible == true {
             self.delegate?.nonModalAlertWindowControllerDidCancel(self)
         }
@@ -58,13 +54,13 @@ class NonModalAlertWindowController: NSWindowController {
         newFrame.origin.x += oldFrame.size.width - newFrame.size.width
         confirmButton.frame = newFrame
 
-        if let cancelButtonTitle {
+        if let cancelButtonTitle = cancelButtonTitle {
             cancelButton.title = cancelButtonTitle
             cancelButton.sizeToFit()
-            var adjustFrame = confirmButton.frame
+            var adjustFrame = cancelButton.frame
             adjustFrame.size.width = max(90, adjustFrame.size.width + 10)
             adjustFrame.origin.x = newFrame.origin.x - adjustFrame.size.width
-            confirmButton.frame = adjustFrame
+            cancelButton.frame = adjustFrame
             cancelButton.isHidden = false
         } else {
             cancelButton.isHidden = true
@@ -92,9 +88,7 @@ class NonModalAlertWindowController: NSWindowController {
         var infiniteHeightFrame = oldFrame
         infiniteHeightFrame.size.width -= 4.0
         infiniteHeightFrame.size.height = 10240
-        newFrame = (content as NSString).boundingRect(
-            with: infiniteHeightFrame.size, options: [.usesLineFragmentOrigin],
-            attributes: [.font: contentTextField.font!])
+        newFrame = (content as NSString).boundingRect(with: infiniteHeightFrame.size, options: [.usesLineFragmentOrigin], attributes: [.font: contentTextField.font!])
         newFrame.size.width = max(newFrame.size.width, oldFrame.size.width)
         newFrame.size.height += 4.0
         newFrame.origin = oldFrame.origin
@@ -110,12 +104,12 @@ class NonModalAlertWindowController: NSWindowController {
         NSApp.activate(ignoringOtherApps: true)
     }
 
-    @IBAction func confirmButtonAction(_ sender: Any?) {
+    @IBAction func confirmButtonAction(_ sender: Any) {
         delegate?.nonModalAlertWindowControllerDidConfirm(self)
         window?.orderOut(self)
     }
 
-    @IBAction func cancelButtonAction(_ sender: Any?) {
+    @IBAction func cancelButtonAction(_ sender: Any) {
         cancel(sender)
     }
 

--- a/Source/Mac/NonModalAlertWindowController.xib
+++ b/Source/Mac/NonModalAlertWindowController.xib
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23094" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
+        <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23094"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -20,13 +21,14 @@
             <windowStyleMask key="styleMask" titled="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="240" width="420" height="130"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1055"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1415"/>
             <view key="contentView" id="2">
                 <rect key="frame" x="0.0" y="0.0" width="420" height="130"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="5">
-                        <rect key="frame" x="331" y="13" width="75" height="32"/>
+                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5">
+                        <rect key="frame" x="314" y="13" width="92" height="32"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                         <buttonCell key="cell" type="push" title="Button" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="6">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -35,8 +37,9 @@
                             <action selector="confirmButtonAction:" target="-2" id="85"/>
                         </connections>
                     </button>
-                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="71">
-                        <rect key="frame" x="256" y="13" width="75" height="32"/>
+                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="71">
+                        <rect key="frame" x="222" y="13" width="92" height="32"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                         <buttonCell key="cell" type="push" title="Button" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="73">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -45,24 +48,23 @@
                             <action selector="cancelButtonAction:" target="-2" id="86"/>
                         </connections>
                     </button>
-                    <imageView translatesAutoresizingMaskIntoConstraints="NO" id="12">
+                    <imageView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="12">
                         <rect key="frame" x="24" y="50" width="64" height="64"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="AlertIcon" id="13"/>
                     </imageView>
-                    <textField focusRingType="none" verticalHuggingPriority="749" translatesAutoresizingMaskIntoConstraints="NO" id="39">
+                    <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="39">
                         <rect key="frame" x="103" y="97" width="300" height="17"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Lorem ipsum" id="40">
                             <font key="font" metaFont="systemBold"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" preferredMaxLayoutWidth="296" translatesAutoresizingMaskIntoConstraints="NO" id="59">
+                    <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" preferredMaxLayoutWidth="296" translatesAutoresizingMaskIntoConstraints="NO" id="59">
                         <rect key="frame" x="103" y="72" width="300" height="17"/>
-                        <constraints>
-                            <constraint firstAttribute="width" constant="296" id="K0Q-KD-INC"/>
-                            <constraint firstAttribute="height" constant="17" id="ZZg-7l-87B"/>
-                        </constraints>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Lorem ipsum" id="60">
                             <font key="font" metaFont="smallSystem"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -70,21 +72,6 @@
                         </textFieldCell>
                     </textField>
                 </subviews>
-                <constraints>
-                    <constraint firstItem="12" firstAttribute="top" secondItem="2" secondAttribute="top" constant="16" id="4Oh-wy-3df"/>
-                    <constraint firstItem="59" firstAttribute="leading" secondItem="12" secondAttribute="trailing" constant="17" id="Dut-Wd-Mem"/>
-                    <constraint firstItem="59" firstAttribute="trailing" secondItem="39" secondAttribute="trailing" id="MRc-pf-lXG"/>
-                    <constraint firstItem="59" firstAttribute="top" secondItem="39" secondAttribute="bottom" constant="8" symbolic="YES" id="RLf-J2-WZt"/>
-                    <constraint firstAttribute="trailing" secondItem="5" secondAttribute="trailing" constant="21" id="SEd-Mj-nEQ"/>
-                    <constraint firstAttribute="trailing" secondItem="59" secondAttribute="trailing" constant="19" id="WcY-NX-v5D"/>
-                    <constraint firstAttribute="bottom" secondItem="5" secondAttribute="bottom" constant="20" symbolic="YES" id="YfP-gn-vb7"/>
-                    <constraint firstItem="5" firstAttribute="leading" secondItem="71" secondAttribute="trailing" constant="14" id="bBf-2y-n0k"/>
-                    <constraint firstItem="5" firstAttribute="top" secondItem="59" secondAttribute="bottom" constant="32" id="cIW-ka-ahH"/>
-                    <constraint firstAttribute="bottom" secondItem="12" secondAttribute="bottom" constant="50" id="geq-JL-fU3"/>
-                    <constraint firstItem="12" firstAttribute="top" secondItem="39" secondAttribute="top" id="k0e-RP-ebs"/>
-                    <constraint firstItem="5" firstAttribute="baseline" secondItem="71" secondAttribute="baseline" id="vef-q4-VyI"/>
-                    <constraint firstItem="59" firstAttribute="leading" secondItem="39" secondAttribute="leading" id="xqG-nX-vGS"/>
-                </constraints>
             </view>
             <connections>
                 <outlet property="delegate" destination="-2" id="4"/>

--- a/Source/Mac/Preferences/GeneralPreferencesViewController.swift
+++ b/Source/Mac/Preferences/GeneralPreferencesViewController.swift
@@ -41,7 +41,7 @@ class GeneralPreferencesViewController: BasePreferencesViewController {
         NotificationCenter.default.removeObserver(self)
     }
 
-    override class func awakeFromNib() {
+    override func awakeFromNib() {
         super.awakeFromNib()
         NotificationCenter.default.addObserver(
             self, selector: #selector(handleUpdateCheckDidComplete(_:)),

--- a/Source/Mac/UpdateChecker.swift
+++ b/Source/Mac/UpdateChecker.swift
@@ -55,11 +55,15 @@ class UpdateChecker: NSObject {
         if busy {
             return
         }
-        let nextCheckDate = self.nextUpdateCheckDate
-        let now = Date()
-        if nextCheckDate != nil && nextCheckDate?.compare(now) != ComparisonResult.orderedAscending {
-            return
+
+        if !forced {
+            let nextCheckDate = self.nextUpdateCheckDate
+            let now = Date()
+            if nextCheckDate != nil && nextCheckDate?.compare(now) != ComparisonResult.orderedAscending {
+                return
+            }
         }
+
         guard let url = URL(string: OVUpdateCheckInfoURLString) else {
             return
         }

--- a/Source/Mac/UpdateChecker.swift
+++ b/Source/Mac/UpdateChecker.swift
@@ -64,7 +64,7 @@ class UpdateChecker: NSObject {
             }
         }
 
-        guard let url = URL(string: OVUpdateCheckInfoURLString) else {
+        guard let url = URL(string: OVUpdateCheckInfoURLString + (forced ? "?manual=yes" : "")) else {
             return
         }
 

--- a/Source/Mac/preferences.xib
+++ b/Source/Mac/preferences.xib
@@ -10,12 +10,10 @@
             <connections>
                 <outlet property="addTableBasedInputMethodViewController" destination="168" id="175"/>
                 <outlet property="arrayModulePreferencesViewController" destination="167" id="YzL-Xb-GWO"/>
-                <outlet property="arrayMoudlePreferencesViewController" destination="167" id="174"/>
                 <outlet property="associatedPhrasesPreferencesViewController" destination="OTa-5M-Vdi" id="RaC-76-EEF"/>
                 <outlet property="generalPreferencesViewController" destination="70" id="74"/>
                 <outlet property="modulePreferencesContainerView" destination="59" id="68"/>
                 <outlet property="tableBasedModulePreferencesViewController" destination="69" id="buv-tw-HAl"/>
-                <outlet property="tableBasedMoudlePreferencesViewController" destination="69" id="73"/>
                 <outlet property="tableView" destination="4" id="65"/>
                 <outlet property="window" destination="1" id="58"/>
             </connections>


### PR DESCRIPTION
This PR fixes a number of issues found in the version update checking mechanism in 1.7.x:

- The forced-check logic is restored
- `GeneralPreferenceViewController` now listens to the `UpdateCheckerDidFinishChecking` notification correctly
   - Also removed two extraneous connections in the `.xib` file, which caused warnings in runtime though did not affect functionalities
- `NonModalAlertWindowController` now synced with McBopomofo's to fix the same issue found here https://github.com/openvanilla/McBopomofo/pull/468
- Implement the missing `busy` property in `UpdateChecker`

This PR also updates the update checker so that it now adds a `?manual=yes` query parameter when the check is forced (that is, triggered manually by the user from OpenVanilla's preferences).
