### PR TITLE
Removes the workaround for terminal app on macOS 10.5.

### DIFF
--- a/Source/Mac/OVInputMethodController.mm
+++ b/Source/Mac/OVInputMethodController.mm
@@ -210,17 +210,6 @@ using namespace OpenVanilla;
 
 - (void)commitComposition:(id)sender
 {
-    NSString *osVersion = [[NSProcessInfo processInfo] operatingSystemVersionString];
-    NSString *termialFixedVersion = @"15.0.1";
-    
-    if ([osVersion compare:termialFixedVersion options:NSNumericSearch] == NSOrderedAscending) {
-        // fix the premature commit bug in Terminal.app since OS X 10.5
-        if ([[sender bundleIdentifier] isEqualToString:@"com.apple.Terminal"] && ![NSStringFromClass([sender class]) isEqualToString:@"IPMDServerClientWrapper"]) {
-            [self performSelector:@selector(updateClientComposingBuffer:) withObject:_currentClient afterDelay:0.0];
-            return;
-        }
-    }
-
     if (_composingText->isCommitted()) {
         NSString *combinedText = @(_composingText->composedCommittedText().c_str());
         NSString *filteredText = [[OVModuleManager defaultManager] filteredStringWithString:combinedText];


### PR DESCRIPTION
This is for issue #85.

On macOS 10.5, we have to defer the input event to let the Terminal app to receive the updates of the composing buffer and the input text. The issue should be already fix for a long time, and such a delay may cause issue on macOS 15. It is time to remove the workaround.