### PR TITLE
Remove the last deferred visual update workaround

### DIFF
--- a/Source/Mac/OVInputMethodController.mm
+++ b/Source/Mac/OVInputMethodController.mm
@@ -552,27 +552,6 @@ using namespace OpenVanilla;
         _readingText->finishUpdate();
     }
 
-    NSArray *params = @[sender, attrString, [NSValue valueWithRange:selectionRange]];
-    // If the sender is Chrome, use a 1/20 sec delay. This is likely because some
-    // internally async updates need to catch up. This is considered a hack, not a
-    // real solution. Please see these two long-standing bugs below, which also
-    // affect Google Japanese Input on Mac as well as Apple's built-in Pinyin IME:
-    // https://bugs.chromium.org/p/chromium/issues/detail?id=86460
-    // https://bugs.chromium.org/p/chromium/issues/detail?id=580808
-    if ([[sender bundleIdentifier] isEqualToString:@"com.google.Chrome"]) {
-        [self performSelector:@selector(deferredUpdateClientComposingBuffer:) withObject:params afterDelay:0.05];
-    }
-    else {
-        [self deferredUpdateClientComposingBuffer:params];
-    }
-}
-
-- (void)deferredUpdateClientComposingBuffer:(NSArray *)params
-{
-    id sender = params[0];
-    NSAttributedString *attrString = params[1];
-    NSRange selectionRange = [params[2] rangeValue];
-
     NSUInteger cursorIndex = selectionRange.location;
     if (cursorIndex == attrString.length && cursorIndex) {
         cursorIndex--;
@@ -600,7 +579,6 @@ using namespace OpenVanilla;
         toolTipText = _composingText->toolTipText();
     }
 
-//    NSLog(@"toolTipText: %@", [NSString stringWithUTF8String:toolTipText.c_str()]);
     if (toolTipText.length()) {
         NSPoint toolTipOrigin = lineHeightRect.origin;
         BOOL fromTopLeft = YES;


### PR DESCRIPTION
### **User description**
The deferred candidate panel update was introduced to address #16 in 2017 but it has no longer been needed since long time ago.

This is also related to #85 regarding code cleanup.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Removed outdated workaround for deferred visual updates.

- Simplified code by removing Chrome-specific handling logic.

- Improved maintainability by eliminating unnecessary methods.

- Addressed legacy issues related to candidate panel updates.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>OVInputMethodController.mm</strong><dd><code>Removed outdated workaround and simplified logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Source/Mac/OVInputMethodController.mm

<li>Removed Chrome-specific deferred update logic.<br> <li> Deleted <code>deferredUpdateClientComposingBuffer</code> method.<br> <li> Simplified <code>updateClientComposingBuffer</code> logic.<br> <li> Cleaned up legacy comments and unused code.


</details>


  </td>
  <td><a href="https://github.com/openvanilla/openvanilla/pull/100/files#diff-492776e3c5ca72c5e0d072c9e625bc4863a2240718b2df062752195c2d870e1e">+0/-22</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information