### PR TITLE
Fix a big in the version update checker; also be conservative in input method controller's -activateServer:

### DIFF
--- a/Source/Mac/OVInputMethodController.mm
+++ b/Source/Mac/OVInputMethodController.mm
@@ -142,7 +142,10 @@ using namespace OpenVanilla;
     [OVModuleManager defaultManager].candidateService->resetAll();
 
     NSString *keyboardLayout = [[OVModuleManager defaultManager] alphanumericKeyboardLayoutForInputMethod:[OVModuleManager defaultManager].activeInputMethodIdentifier];
-    [client overrideKeyboardWithKeyboardNamed:keyboardLayout];
+
+    if ([client respondsToSelector:@selector(overrideKeyboardWithKeyboardNamed:)]) {
+        [client overrideKeyboardWithKeyboardNamed:keyboardLayout];
+    }
 
     [[OVModuleManager defaultManager] synchronizeActiveInputMethodSettings];
 


### PR DESCRIPTION
The Swift version of UpdateChecker uses the shorter `OVNextUpdateCheckRetryInterval` when setting the next udpate check time. This PR restores the logic in the Objective-C version, which uses the regular `OVNextUpdateCheckInterval` instead. The shorter retry interval is only used if there is a network error.

This also makes a small change to `OVInputMethodController`. This is to avoid the case where an application passes an IMK client instance that is not well implemented.

## How Tested

Manually verified that the `NextUpdateCheckTime` user preference in now set correctly.
