### PR TITLE
Show fatal error if no installable package found

### DIFF
--- a/Source/Mac/Installer/AppDelegate.swift
+++ b/Source/Mac/Installer/AppDelegate.swift
@@ -180,6 +180,9 @@ class AppDelegate: NSWindowController, NSApplicationDelegate {
 
     func installInputMethod(previousExists: Bool, previousVersionNotFullyDeactivatedWarning warning: Bool) {
         guard let targetBundle = archiveUtil?.unzipNotarizedArchive() ?? Bundle.main.path(forResource: kTargetBin, ofType: kTargetType) else {
+            let message = NSLocalizedString("No installable packages found.", comment: "")
+            runAlertPanel(title: NSLocalizedString("Fatal Error", comment: ""), message: message, buttonTitle: NSLocalizedString("Abort", comment: ""))
+            endAppWithDelay()
             return
         }
         let cpTask = Process()
@@ -193,6 +196,7 @@ class AppDelegate: NSWindowController, NSApplicationDelegate {
                           message: NSLocalizedString("Cannot copy the file to the destination.", comment: ""),
                           buttonTitle: NSLocalizedString("Cancel", comment: ""))
             endAppWithDelay()
+            return
         }
 
         guard let imeBundle = Bundle(path: (kTargetPartialPath as NSString).expandingTildeInPath),

--- a/Source/Mac/Installer/en.lproj/Localizable.strings
+++ b/Source/Mac/Installer/en.lproj/Localizable.strings
@@ -49,6 +49,7 @@
 
 "Fatal Error" = "Fatal Error";
 "Abort" = "Abort";
+"No installable packages found." = "No installable packages found.";
 "Cannot register input source %@ at %@." = "Cannot register input source %@ at %@.";
 "Cannot find input source %@ after registration." = "Cannot find input source %@ after registration.";
 

--- a/Source/Mac/Installer/zh-Hans.lproj/Localizable.strings
+++ b/Source/Mac/Installer/zh-Hans.lproj/Localizable.strings
@@ -48,6 +48,7 @@
 
 "Fatal Error" = "安装错误";
 "Abort" = "放弃安装";
+"No installable packages found." = "找不到可安装的输入法软件包。";
 "Cannot register input source %@ at %@." = "无法从文件位置 %2$@ 安装输入法 \"%1$@\"。";
 "Cannot find input source %@ after registration." = "在注册完输入法 \"%@\" 仍然无法找到输入法。";
 

--- a/Source/Mac/Installer/zh-Hant.lproj/Localizable.strings
+++ b/Source/Mac/Installer/zh-Hant.lproj/Localizable.strings
@@ -48,6 +48,7 @@
 
 "Fatal Error" = "安裝錯誤";
 "Abort" = "放棄安裝";
+"No installable packages found." = "找不到可安裝的輸入法套件。";
 "Cannot register input source %@ at %@." = "無法從檔案位置 %2$@ 安裝輸入法 \"%1$@\"。";
 "Cannot find input source %@ after registration." = "在註冊完輸入法 \"%@\" 仍然無法找到輸入法。";
 


### PR DESCRIPTION
### **User description**
This is for #105, just to make the installer more robust. This *shouldn't* happen, but it's good to have a diagnostic message if it does.

## How Tested

Manually hit the code path to make sure that the error dialog box indeed appears in the calamitous scenario.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added a fatal error message for missing installable packages.

- Updated localization files with new error message translations.

- Improved error handling in the installer process.

- Ensured application termination after critical errors.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AppDelegate.swift</strong><dd><code>Enhanced error handling in installer logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Source/Mac/Installer/AppDelegate.swift

<li>Added a fatal error message when no installable package is found.<br> <li> Ensured application terminates after showing the error message.<br> <li> Improved error handling for failed file copy operations.


</details>


  </td>
  <td><a href="https://github.com/openvanilla/openvanilla/pull/107/files#diff-221bfb7efcd8463ecbde9d32f859faf3e3e3180e834cc8900a29007e34eeec6f">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Localizable.strings</strong><dd><code>Added English localization for new error message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Source/Mac/Installer/en.lproj/Localizable.strings

<li>Added a new localized string for "No installable packages found."<br> <li> Updated English localization for error messages.


</details>


  </td>
  <td><a href="https://github.com/openvanilla/openvanilla/pull/107/files#diff-4d6b79f894792e4737a9d1953d924282d2ee32692a195fa55cec0232df2e2ff3">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Localizable.strings</strong><dd><code>Added Simplified Chinese localization for new error message</code></dd></summary>
<hr>

Source/Mac/Installer/zh-Hans.lproj/Localizable.strings

<li>Added a new localized string for "No installable packages found."<br> <li> Updated Simplified Chinese localization for error messages.


</details>


  </td>
  <td><a href="https://github.com/openvanilla/openvanilla/pull/107/files#diff-4cd4456dc944334acdd73e139d6f46629fc05dda042ca28def7a932ad3a15682">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Localizable.strings</strong><dd><code>Added Traditional Chinese localization for new error message</code></dd></summary>
<hr>

Source/Mac/Installer/zh-Hant.lproj/Localizable.strings

<li>Added a new localized string for "No installable packages found."<br> <li> Updated Traditional Chinese localization for error messages.


</details>


  </td>
  <td><a href="https://github.com/openvanilla/openvanilla/pull/107/files#diff-7f13b5926930066cf22ad81146be98dd953433aa709d172646f0f25e12b01574">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>