### PR TITLE
Fix a regression caused by PR #116

### DIFF
--- a/Packages/OpenVanilla/Sources/OpenVanillaImpl/OVOneDimensionalCandidatePanelImpl.mm
+++ b/Packages/OpenVanilla/Sources/OpenVanillaImpl/OVOneDimensionalCandidatePanelImpl.mm
@@ -101,7 +101,7 @@ static bool IsKeyInList(const OVKey* key, OVKeyVector list, size_t* outIndex = 0
 }
 
 - (NSString * _Nullable)candidateController:(VTCandidateController * _Nonnull)controller readingAtIndex:(NSUInteger)index {
-    return nil;
+    return _candidateList->candidateAtIndex(index);
 }
 
 

--- a/Packages/SystemCharacterInfo/Sources/SystemCharacterInfo/SystemCharacterInfo.swift
+++ b/Packages/SystemCharacterInfo/Sources/SystemCharacterInfo/SystemCharacterInfo.swift
@@ -120,7 +120,6 @@ private let path = "/System/Library/PrivateFrameworks/CoreChineseEngine.framewor
             let result = getSingleExplanation(string: String(char)) ?? string
             results.append(result)
         }
-        NSLog("results?? \(results)")
         switch results.count {
         case 0:
             return string


### PR DESCRIPTION
This commit supplies the candidate as the reading, otherwise the recently updated vertical candidate panel won't call SystemCharacterInfo to fetch the information.

Also removes one extraneous logging in `SystemCharacterInfo.swift`.