### PR TITLE
修正垂直選字窗在開啟聯想詞後頁面錯亂的問題

### DIFF
--- a/Packages/OpenVanilla/Sources/OpenVanillaImpl/OVOneDimensionalCandidatePanelImpl.mm
+++ b/Packages/OpenVanilla/Sources/OpenVanillaImpl/OVOneDimensionalCandidatePanelImpl.mm
@@ -518,11 +518,7 @@ OVOneDimensionalCandidatePanelImpl::KeyHandlerResult OVOneDimensionalCandidatePa
         size_t index = currentHightlightIndexInCandidateList();
         size_t cpp = candidatesPerPage();
         if (!index) {
-            size_t lastIndex = m_candidateList.size();
-            if (lastIndex) {
-                lastIndex--;
-            }
-            index = (lastIndex / cpp) * cpp;
+            index = m_candidateList.size() - 1;
         } else {
             if (index > cpp) {
                 index -= cpp;


### PR DESCRIPTION
這個 PR 修正從小麥注音同步來的垂直選字窗所帶來的問題。這一段程式碼是[九月時](https://github.com/openvanilla/openvanilla/commit/50929465a7b6a603975ec69dce2387b5365aa3c3)帶進來的。問題出在先前計算翻頁後、table view 要捲動到哪一行的程式，只考慮到[連續翻頁](https://github.com/openvanilla/McBopomofo/pull/453)的情境──但是 OV 的聯想詞模組直接要求翻到第 0 頁（等於是選取第 0 個候選字詞），結果那一段程式就誤算了 table view 要捲動到的行數，並且讓後續的選字窗狀態連帶錯亂。我們在小麥注音中[修正了這一段的計算邏輯](https://github.com/openvanilla/McBopomofo/pull/755)，在此同步過來。

這個 PR 同時修正一個無關的問題：選字窗在第 0 頁，按 Page Up 時，選字窗應該倒卷至最後一頁，且高亮選取最後一個候選字詞。但先前的邏輯選到的是倒數第二個候選字詞，而不是最後一個。

Fixes #119